### PR TITLE
feat: Upgrade Jupiter API and add WebSocket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,9 +1446,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bytestring"
@@ -2433,6 +2433,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fastwebsockets"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26da0c7b5cef45c521a6f9cdfffdfeb6c9f5804fbac332deb5ae254634c7a6be"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "pin-project",
+ "rand 0.8.5",
+ "sha1",
+ "simdutf8",
+ "thiserror 1.0.69",
+ "tokio",
+ "utf-8",
+]
+
+[[package]]
 name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,12 +3011,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -3046,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3057,6 +3077,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3111,7 +3132,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3121,20 +3142,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -3530,10 +3550,14 @@ dependencies = [
  "dialoguer 0.11.0",
  "dotenv",
  "env_logger 0.11.3",
+ "fastwebsockets",
  "flame",
  "flamer",
  "flexi_logger",
  "futures-util",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
  "indicatif",
  "jito-protos",
  "jito-searcher-client",
@@ -3558,6 +3582,7 @@ dependencies = [
  "thiserror 2.0.9",
  "timed",
  "tokio",
+ "tokio-native-tls",
  "tokio-test",
  "tonic",
  "warp",
@@ -4995,7 +5020,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.5.2",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -5726,6 +5751,12 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sized-chunks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,8 @@ borsh = "0.10.3"
 indicatif = "0.17"
 rig-core = "0.6.0"
 thiserror = "2.0.9"
+fastwebsockets = { version = "0.8.0", features = ["upgrade"] }
+hyper = { version = "1.4.1", features = ["full"] }
+tokio-native-tls = "0.3.1"
+hyper-util = "0.1.7"
+http-body-util = "0.1.2"

--- a/src/buyer.rs
+++ b/src/buyer.rs
@@ -349,6 +349,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
 
     #[tokio::test]
+    #[ignore]
     async fn test_check_if_pump_fun_works_for_pump_fun() {
         // some pump fun shitto
         let mint =

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -46,6 +46,7 @@ mod tests {
     use crate::checker_service::TokenResult;
 
     #[tokio::test]
+    #[ignore]
     async fn test_collector() {
         let collector = super::new().await.unwrap();
         let token_result = TokenResult::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@ pub mod seller_service;
 pub mod tx_parser;
 pub mod types;
 pub mod util;
+pub mod ws;
 
 mod tests;
 

--- a/src/orca.rs
+++ b/src/orca.rs
@@ -95,7 +95,7 @@ mod tests {
 
         assert_eq!(whirlpool.fee_rate, 3000);
         assert_eq!(whirlpool.protocol_fee_rate, 1300);
-        assert_eq!(whirlpool.token_mint_a.to_string(), SOLANA_PROGRAM_ID);
+        assert_eq!(whirlpool.token_mint_a, SOLANA_PROGRAM_ID);
         assert_eq!(
             whirlpool.token_mint_b.to_string(),
             "CTJf74cTo3cw8acFP1YXF3QpsQUUBGBjh2k2e8xsZ6UL" // $neiro

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -123,11 +123,11 @@ impl Provider {
         mint: &str,
     ) -> Result<types::PriceResponse, Box<dyn std::error::Error>> {
         let url = format!(
-            "https://price.jup.ag/v4/price?ids={}&vsToken={}",
+            "https://api.jup.ag/price/v2?ids={},{}",
             mint,
             constants::SOLANA_PROGRAM_ID,
         );
-        debug!("Getting pricing from: {:?}", url);
+        println!("Getting pricing from: {:?}", url);
         let client = reqwest::Client::new();
         let res = client
             .get(url)
@@ -165,6 +165,10 @@ impl Provider {
         }
     }
 
+    /// sanity_check is for mint_authority and freeze_authority, for non
+    /// pump.fun tokens is crucial, mint authority enables minting any amount of
+    /// the token and freeze authority can renounce the ability to trade the
+    /// token for a given address
     #[timed(duration(printer = "info!"))]
     pub async fn sanity_check(
         &self,

--- a/src/pump.rs
+++ b/src/pump.rs
@@ -1008,10 +1008,11 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[ignore]
     async fn test_pump_bump() {
         dotenv::from_filename(".env").unwrap();
-        let wallet =
-            Keypair::read_from_file("./wtf.json").expect("read wallet");
+        let wallet = Keypair::read_from_file(env("FUND_KEYPAIR_PATH"))
+            .expect("read wallet");
         let rpc_client =
             RpcClient::new("https://api.mainnet-beta.solana.com".to_string());
         let mint =
@@ -1092,6 +1093,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn test_buy_pump_token() {
         dotenv::from_filename(".env").unwrap();
         // 0.00069 sol
@@ -1115,10 +1117,9 @@ mod tests {
             .expect("parse associated user"),
             metadata: Pubkey::default(), // not required
         };
-        let wallet =
-            Keypair::read_from_file("./fuck.json").expect("read wallet");
-        let rpc_client =
-            RpcClient::new("https://api.mainnet-beta.solana.com".to_string());
+        let wallet = Keypair::read_from_file(env("FUND_KEYPAIR_PATH"))
+            .expect("read wallet");
+        let rpc_client = RpcClient::new(env("RPC_URL").to_string());
         let auth = Arc::new(
             Keypair::read_from_file(env("AUTH_KEYPAIR_PATH")).unwrap(),
         );
@@ -1141,8 +1142,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bonding_curve_incomplete() {
-        let rpc_client =
-            RpcClient::new("https://api.mainnet-beta.solana.com".to_string());
+        dotenv::from_filename(".env").unwrap();
+        let rpc_client = RpcClient::new(env("RPC_URL").to_string());
         let bonding_curve_pubkey = Pubkey::from_str(
             "Drhj4djqLsPyiA9qK2YmBngteFba8XhhvuQoBToW6pMS", // some shitter
         )
@@ -1163,8 +1164,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_bonding_curve_complete() {
-        let rpc_client =
-            RpcClient::new("https://api.mainnet-beta.solana.com".to_string());
+        dotenv::from_filename(".env").unwrap();
+        let rpc_client = RpcClient::new(env("RPC_URL").to_string());
         let bonding_curve_pubkey = Pubkey::from_str(
             "EB5tQ64HwNjaEoKKYAPkZqndwbULX249EuWSnkjfvR3y", // michi
         )

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,3 +1,4 @@
+use crate::raydium::make_compute_budget_ixs;
 use log::info;
 use solana_client::{
     rpc_client::RpcClient,
@@ -5,14 +6,10 @@ use solana_client::{
 };
 use solana_sdk::{
     commitment_config::{CommitmentConfig, CommitmentLevel},
-    pubkey::Pubkey,
     signature::{Keypair, Signature},
     signer::{EncodableKey, Signer},
     transaction::Transaction,
 };
-use std::str::FromStr;
-
-use crate::raydium::make_compute_budget_ixs;
 
 pub fn eval_rpc(rpc_url: &str) {
     info!("Evaluating RPC: {}", rpc_url);
@@ -30,8 +27,7 @@ pub fn eval_rpc(rpc_url: &str) {
     ixs.append(&mut make_compute_budget_ixs(price, max_units));
     ixs.push(solana_sdk::system_instruction::transfer(
         &wallet.pubkey(),
-        &Pubkey::from_str("9SDTi7rzsCt1Y1QDY4n6NvFHn33tcYoVYfoEuXR7dQEM")
-            .unwrap(),
+        &wallet.pubkey(),
         lamports,
     ));
     let transaction = Transaction::new_signed_with_payer(

--- a/src/seller.rs
+++ b/src/seller.rs
@@ -306,6 +306,8 @@ mod tests {
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
 
+    use crate::util::env;
+
     use super::{unpack, AmmInfo};
 
     #[tokio::test]
@@ -313,11 +315,8 @@ mod tests {
         let mint =
             Pubkey::from_str("6hm9tDfhnhVCBD6Qk8L27WabnbzfUJFs5jQpdLnNVAET")
                 .unwrap();
-        let decimals = super::get_decimals(
-            &mint,
-            &RpcClient::new("https://api.mainnet-beta.solana.com".to_string()),
-        )
-        .await;
+        let decimals =
+            super::get_decimals(&mint, &RpcClient::new(env("RPC_URL"))).await;
         assert!(decimals == 5u8);
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,20 +9,16 @@ use crate::{
     util::env,
 };
 
-const RPC_URL: &str = "https://api.mainnet-beta.solana.com";
-
 #[test]
-#[ignore = "This test requires a live network connection"]
 fn test_get_pricing() {
-    let provider = crate::provider::Provider::new(RPC_URL.to_string());
-    let mint = "Fv17uvL3nsD4tBJaowdKz9SUsKFoxeZdcTuGTaKgyYQU";
+    let provider = crate::provider::Provider::new(env("RPC_URL"));
+    let mint = "Cn5Ne1vmR9ctMGY9z5NC71A3NYFvopjXNyxYtfVYpump";
 
     let pricing = tokio_test::block_on(provider.get_pricing(mint)).unwrap();
     assert!(pricing.data[mint].price > 0., "Price not found");
 }
 
 #[test]
-#[ignore = "not used atm"]
 fn test_parse_notional() {
     let tx =
         serde_json::from_reader(std::fs::File::open("mock/tx.json").unwrap())
@@ -32,13 +28,11 @@ fn test_parse_notional() {
 }
 
 #[tokio::test]
-#[ignore = "This test requires a live network connection"]
 async fn test_parse_new_pool() {
     let new_pool_tx_signature: &str =
         "2nkbEdznrqqoXyxcrYML8evHtAKcNTurBBXGWACS6cxJDHYGosgVdy66gaqHzgtRWWH13bzMF4kovSEQUVYdDPku";
-    let provider = Provider::new(RPC_URL.to_string());
+    let provider = crate::provider::Provider::new(env("RPC_URL"));
     let tx = provider.get_tx(new_pool_tx_signature).await.unwrap();
-    println!("{}", serde_json::to_string_pretty(&tx).unwrap());
     let new_pool_info = tx_parser::parse_new_pool(&tx).unwrap();
     assert_eq!(
         new_pool_info.amm_pool_id.to_string(),
@@ -61,7 +55,7 @@ async fn test_sanity_check() {
     let mint =
         Pubkey::from_str("3jGenV1FXBQWKtviJUWXUwXFiA8TNV4QGF2n499HnJmw")
             .unwrap();
-    let provider = Provider::new(RPC_URL.to_string());
+    let provider = crate::provider::Provider::new(env("RPC_URL"));
     assert!(!provider.sanity_check(&mint).await.unwrap().0);
     // michi
     let mint =
@@ -78,13 +72,12 @@ fn test_parse_mint_acc() {
 }
 
 #[tokio::test]
-#[ignore = "requires a live network connection"]
 async fn test_gets_top_holders() {
     let mint =
         Pubkey::from_str("D2oKMNHb94DSgvibQxCweZPrbFEhayKBQ5eaPMC4Dvnv")
             .unwrap();
-    let (_, ok) =
-        check_top_holders(&mint, &Provider::new(env("RPC_URL")))
+    let (_, ok, _) =
+        check_top_holders(&mint, &Provider::new(env("RPC_URL")), false)
             .await
             .unwrap();
     assert!(ok);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
 use std::collections::HashMap;
 
 #[serde_with::skip_serializing_none]
@@ -9,13 +10,11 @@ pub struct PriceResponse {
     pub time_taken: f64,
 }
 
+#[serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
 pub struct PriceData {
     pub id: String,
-    pub mint_symbol: String,
-    pub vs_token: String,
-    pub vs_token_symbol: String,
+    #[serde_as(as = "DisplayFromStr")]
     pub price: f64,
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,0 +1,154 @@
+use fastwebsockets::handshake;
+use fastwebsockets::WebSocket;
+use http_body_util::Empty;
+use hyper::{
+    body::Bytes,
+    header::{CONNECTION, UPGRADE},
+    upgrade::Upgraded,
+    Request,
+};
+use hyper_util::rt::TokioIo;
+use log::info;
+use std::error::Error;
+use std::future::Future;
+use tokio::net::TcpStream;
+
+// URLs
+pub const PUMP_WS_URL: &str =
+    "https://frontend-api.pump.fun/socket.io/?EIO=4&transport=websocket";
+pub const PUMP_WS_HOST: &str = "frontend-api.pump.fun";
+pub const PUMP_PORTAL_WS_URL: &str = "https://pumpportal.fun/api/data";
+pub const PUMP_PORTAL_WS_HOST: &str = "pumpportal.fun";
+
+pub async fn connect_to_pump_portal_websocket(
+) -> Result<WebSocket<TokioIo<Upgraded>>, Box<dyn Error>> {
+    _connect_to_websocket(
+        PUMP_PORTAL_WS_HOST.to_string(),
+        PUMP_PORTAL_WS_URL.to_string(),
+    )
+    .await
+}
+
+#[timed::timed(duration(printer = "info!"))]
+pub async fn _connect_to_websocket(
+    host: String,
+    url: String,
+) -> Result<WebSocket<TokioIo<Upgraded>>, Box<dyn Error>> {
+    let stream = TcpStream::connect(format!("{}:443", host)).await?;
+
+    // Convert the TCP stream to a TLS stream
+    let tls_connector =
+        tokio_native_tls::native_tls::TlsConnector::new().unwrap();
+    let tls_connector = tokio_native_tls::TlsConnector::from(tls_connector);
+    let tls_stream = tls_connector.connect(&host, stream).await?;
+
+    let req = Request::builder()
+        .method("GET")
+        .uri(url)
+        .header("Host", host)
+        .header(UPGRADE, "websocket")
+        .header(CONNECTION, "upgrade")
+        .header(
+            "Sec-WebSocket-Key",
+            fastwebsockets::handshake::generate_key(),
+        )
+        .header("Sec-WebSocket-Version", "13")
+        .body(Empty::<Bytes>::new())?;
+
+    let (ws, _) = handshake::client(&SpawnExecutor, req, tls_stream).await?;
+    Ok(ws)
+}
+
+pub async fn connect_to_jito_tip_websocket(
+) -> Result<WebSocket<TokioIo<Upgraded>>, Box<dyn Error>> {
+    _connect_to_websocket(
+        "bundles.jito.wtf".to_string(),
+        "https://bundles.jito.wtf/api/v1/bundles/tip_stream".to_string(),
+    )
+    .await
+}
+
+#[timed::timed(duration(printer = "info!"))]
+pub async fn _connect_to_websocket_insecure(
+    host: String,
+    url: String,
+) -> Result<WebSocket<TokioIo<Upgraded>>, Box<dyn Error>> {
+    let stream = TcpStream::connect(format!("{}:80", host)).await?;
+    let req = Request::builder()
+        .method("GET")
+        .uri(url)
+        .header("Host", host)
+        .header(UPGRADE, "websocket")
+        .header(CONNECTION, "upgrade")
+        .header(
+            "Sec-WebSocket-Key",
+            fastwebsockets::handshake::generate_key(),
+        )
+        .header("Sec-WebSocket-Version", "13")
+        .body(Empty::<Bytes>::new())?;
+
+    let (ws, _) = handshake::client(&SpawnExecutor, req, stream).await?;
+    Ok(ws)
+}
+
+pub async fn connect_to_pump_websocket(
+) -> Result<WebSocket<TokioIo<Upgraded>>, Box<dyn Error>> {
+    _connect_to_websocket(PUMP_WS_HOST.to_string(), PUMP_WS_URL.to_string())
+        .await
+}
+
+// Tie hyper's executor to tokio runtime
+struct SpawnExecutor;
+
+impl<Fut> hyper::rt::Executor<Fut> for SpawnExecutor
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    fn execute(&self, fut: Fut) {
+        tokio::task::spawn(fut);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fastwebsockets::{Frame, OpCode, Payload};
+
+    use super::*;
+
+    async fn assert_connection(ws: &mut WebSocket<TokioIo<Upgraded>>) {
+        let frame = ws.read_frame().await.expect("read frame");
+        let mut pass = false;
+        match frame.opcode {
+            OpCode::Close => {}
+            OpCode::Text | OpCode::Binary => {
+                pass = true;
+            }
+            _ => {}
+        }
+        assert!(pass);
+    }
+
+    #[tokio::test]
+    async fn connect_to_jito_tip_works() {
+        let mut ws = connect_to_jito_tip_websocket().await.expect("connect");
+        assert_connection(&mut ws).await;
+    }
+
+    #[tokio::test]
+    async fn connect_works() {
+        let mut ws = connect_to_pump_websocket().await.expect("connect");
+        assert_connection(&mut ws).await;
+    }
+
+    #[tokio::test]
+    async fn connect_to_pump_portal_works() {
+        let mut ws =
+            connect_to_pump_portal_websocket().await.expect("connect");
+        let payload = r#"{"method":"subscribeNewToken"}"#;
+        ws.write_frame(Frame::text(Payload::Bytes(payload.into())))
+            .await
+            .expect("write frame");
+        assert_connection(&mut ws).await;
+    }
+}


### PR DESCRIPTION
Key changes:
- Upgrade Jupiter API implementation to use https://station.jup.ag/docs/apis/price-api-v2, (v6 price API was deprecated)
- Add WebSocket support using fastwebsockets for real-time data
- Add Jito over HTTP/1.1, no searcher client required
- Update dependencies including bytes, hyper, and http-body-util
- Add WebSocket connections for pump.fun and Jito tip streams with fastwebsockets
- Ignore some integ tests requiring live network connections (for now)
- Fix price API endpoint and response handling (jup)

