### PR TITLE
implement the swap handlers for listed tokens and pump fun

### DIFF
--- a/src/handlers/balance.rs
+++ b/src/handlers/balance.rs
@@ -8,7 +8,6 @@ use actix_web::{
 };
 use log::info;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use solana_sdk::pubkey::Pubkey;
 
 #[derive(Debug, Deserialize)]
@@ -54,7 +53,7 @@ pub async fn handle_balance(
 ) -> Result<HttpResponse, Error> {
     let balance = Provider::get_balance(&state.rpc_client, &request.pubkey)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(HttpResponse::Ok().json(BalanceResponse {
         pubkey: request.pubkey,
@@ -74,7 +73,7 @@ pub async fn handle_token_balance(
         &request.mint,
     )
     .await
-    .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+    .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(HttpResponse::Ok().json(TokenBalanceResponse {
         pubkey: request.pubkey,
@@ -87,11 +86,10 @@ pub async fn handle_token_balance(
 #[timed::timed(duration(printer = "info!"))]
 pub async fn handle_pricing(
     request: Json<PricingRequest>,
-    state: Data<ServiceState>,
 ) -> Result<HttpResponse, Error> {
     let price_data = Provider::get_pricing(&request.mint)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(HttpResponse::Ok().json(price_data))
 }

--- a/src/handlers/pump_swap.rs
+++ b/src/handlers/pump_swap.rs
@@ -1,3 +1,8 @@
+use crate::jito::send_jito_tx;
+use crate::pump::{
+    _make_buy_ixs, get_bonding_curve, get_token_amount, make_pump_sell_ix,
+    mint_to_pump_accounts,
+};
 use crate::state::ServiceState;
 use crate::util::{pubkey_to_string, string_to_pubkey};
 use actix_web::{
@@ -9,6 +14,8 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signer::Signer;
+use solana_sdk::transaction::Transaction;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PumpBuyRequest {
@@ -16,10 +23,10 @@ pub struct PumpBuyRequest {
         serialize_with = "pubkey_to_string",
         deserialize_with = "string_to_pubkey"
     )]
-    input_mint: Pubkey,
+    mint: Pubkey,
 
-    /// token_amount to buy
-    token_amount: u64,
+    /// sol_amount denoted in lamports
+    sol_amount: u64,
 
     /// slippage in bps
     slippage: u16,
@@ -31,7 +38,7 @@ pub struct PumpSellRequest {
         serialize_with = "pubkey_to_string",
         deserialize_with = "string_to_pubkey"
     )]
-    input_mint: Pubkey,
+    mint: Pubkey,
 
     /// token_amount to sell
     token_amount: u64,
@@ -40,26 +47,104 @@ pub struct PumpSellRequest {
     slippage: u16,
 }
 
-#[post("/pump/buy")]
+#[post("/pump-buy")]
 #[timed::timed(duration(printer = "info!"))]
 pub async fn handle_pump_buy(
     pump_buy_request: Json<PumpBuyRequest>,
-    _state: Data<ServiceState>,
+    state: Data<ServiceState>,
 ) -> Result<HttpResponse, Error> {
+    let pump_buy_request = pump_buy_request.into_inner();
+    let pump_accounts = mint_to_pump_accounts(&pump_buy_request.mint)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let bonding_curve =
+        get_bonding_curve(&state.rpc_client, pump_accounts.bonding_curve)
+            .await
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+    let token_amount = get_token_amount(
+        bonding_curve.virtual_sol_reserves,
+        bonding_curve.virtual_token_reserves,
+        bonding_curve.real_token_reserves,
+        pump_buy_request.sol_amount,
+    )?;
+
+    let keypair = state.wallet.lock().await.insecure_clone();
+
+    let owner = keypair.pubkey();
+
+    let buy_ixs = _make_buy_ixs(
+        owner,
+        pump_accounts.mint,
+        pump_accounts.bonding_curve,
+        pump_accounts.associated_bonding_curve,
+        token_amount,
+        pump_buy_request.sol_amount,
+    )
+    .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let latest_blockhash = *state.latest_blockhash.lock().await;
+
+    let tx = Transaction::new_signed_with_payer(
+        buy_ixs.as_slice(),
+        Some(&owner),
+        &[&keypair],
+        latest_blockhash,
+    );
+
+    let result = send_jito_tx(tx)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
     Ok(HttpResponse::Ok().json(json!({
         "status": "ok",
-        "pump_buy_request": pump_buy_request.into_inner(),
+        "result": result,
     })))
 }
 
-#[post("/pump/sell")]
+#[post("/pump-sell")]
 #[timed::timed(duration(printer = "info!"))]
 pub async fn handle_pump_sell(
     pump_sell_request: Json<PumpSellRequest>,
-    _state: Data<ServiceState>,
+    state: Data<ServiceState>,
 ) -> Result<HttpResponse, Error> {
+    let pump_sell_request = pump_sell_request.into_inner();
+    let pump_accounts = mint_to_pump_accounts(&pump_sell_request.mint)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let keypair = state.wallet.lock().await.insecure_clone();
+
+    let owner = keypair.pubkey();
+
+    let ata = spl_associated_token_account::get_associated_token_address(
+        &owner,
+        &pump_accounts.mint,
+    );
+
+    let ix = make_pump_sell_ix(
+        owner,
+        pump_accounts,
+        pump_sell_request.token_amount,
+        ata,
+    )
+    .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let latest_blockhash = *state.latest_blockhash.lock().await;
+
+    let tx = Transaction::new_signed_with_payer(
+        [ix].as_slice(),
+        Some(&owner),
+        &[&keypair],
+        latest_blockhash,
+    );
+
+    let result = send_jito_tx(tx)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
     Ok(HttpResponse::Ok().json(json!({
         "status": "ok",
-        "pump_sell_request": pump_sell_request.into_inner(),
+        "result": result,
     })))
 }

--- a/src/handlers/swap.rs
+++ b/src/handlers/swap.rs
@@ -1,3 +1,4 @@
+use crate::jup::Jupiter;
 use crate::state::ServiceState;
 use crate::util::{pubkey_to_string, string_to_pubkey};
 use actix_web::{
@@ -11,7 +12,7 @@ use serde_json::json;
 use solana_sdk::pubkey::Pubkey;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct BuyRequest {
+pub struct SwapRequest {
     #[serde(
         serialize_with = "pubkey_to_string",
         deserialize_with = "string_to_pubkey"
@@ -24,45 +25,35 @@ pub struct BuyRequest {
     )]
     output_mint: Pubkey,
 
-    /// slippage in bps
-    slippage: u16,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct SellRequest {
-    #[serde(
-        serialize_with = "pubkey_to_string",
-        deserialize_with = "string_to_pubkey"
-    )]
-    mint: Pubkey,
-
-    /// token_amount
-    token_amount: u64,
+    amount: u64,
 
     /// slippage in bps
     slippage: u16,
 }
 
-#[post("/buy")]
+#[post("/swap")]
 #[timed::timed(duration(printer = "info!"))]
-pub async fn handle_buy(
-    buy_request: Json<BuyRequest>,
-    _state: Data<ServiceState>,
+pub async fn handle_swap(
+    swap_request: Json<SwapRequest>,
+    state: Data<ServiceState>,
 ) -> Result<HttpResponse, Error> {
-    Ok(HttpResponse::Ok().json(json!({
-        "status": "ok",
-        "buy_request": buy_request.into_inner(),
-    })))
-}
+    let swap_request = swap_request.into_inner();
+    let quote = Jupiter::fetch_quote(
+        &swap_request.input_mint.to_string(),
+        &swap_request.output_mint.to_string(),
+        swap_request.amount,
+        swap_request.slippage,
+    )
+    .await
+    .map_err(actix_web::error::ErrorInternalServerError)?;
 
-#[post("/sell")]
-#[timed::timed(duration(printer = "info!"))]
-pub async fn handle_sell(
-    sell_request: Json<SellRequest>,
-    _state: Data<ServiceState>,
-) -> Result<HttpResponse, Error> {
+    let keypair = state.wallet.lock().await.insecure_clone();
+    let result = Jupiter::swap(quote, &keypair)
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
     Ok(HttpResponse::Ok().json(json!({
         "status": "ok",
-        "sell_request": sell_request.into_inner(),
+        "result": result,
     })))
 }

--- a/src/jup.rs
+++ b/src/jup.rs
@@ -165,7 +165,7 @@ impl Jupiter {
     pub async fn swap(
         quote_response: QuoteResponse,
         signer: &Keypair,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<String, Box<dyn std::error::Error>> {
         let swap_request = SwapRequest {
             user_public_key: signer.pubkey().to_string(),
             wrap_and_unwrap_sol: true,
@@ -233,9 +233,9 @@ impl Jupiter {
             Transaction::new_with_payer(&instructions, Some(&signer.pubkey()));
         tx.sign(&[signer], recent_blockhash);
 
-        send_jito_tx(tx).await?;
+        let result = send_jito_tx(tx).await?;
 
-        Ok(())
+        Ok(result)
     }
 
     fn convert_instruction_data(

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,16 +349,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             let coin_mint_is_sol = market_keys.coin_mint.to_string()
                 == constants::SOLANA_PROGRAM_ID.to_string();
-            let owner_balance = provider
-                .get_spl_balance(
-                    &Pubkey::from_str(owner.as_str()).unwrap(),
-                    if coin_mint_is_sol {
-                        &market_keys.pc_mint
-                    } else {
-                        &market_keys.coin_mint
-                    },
-                )
-                .await?;
+            let owner_balance = Provider::get_spl_balance(
+                &rpc_client,
+                &Pubkey::from_str(owner.as_str()).unwrap(),
+                if coin_mint_is_sol {
+                    &market_keys.pc_mint
+                } else {
+                    &market_keys.coin_mint
+                },
+            )
+            .await?;
 
             loop {
                 let result = amm::calculate_pool_vault_amounts(

--- a/src/raydium.rs
+++ b/src/raydium.rs
@@ -417,7 +417,7 @@ pub async fn make_swap_ixs(
     // this step adds some latency, could be pre-calculated while waiting for the JITO leader
     let other_amount_threshold = if !quick {
         let result = raydium_library::amm::calculate_pool_vault_amounts(
-            &rpc_client,
+            rpc_client,
             &swap_context.amm_program,
             &swap_context.amm_pool,
             &swap_context.amm_keys,

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use crate::blockhash::update_latest_blockhash;
 use crate::handlers::{
-    handle_balance, handle_buy, handle_pump_buy, handle_pump_sell, handle_sell,
+    handle_balance, handle_pump_buy, handle_pump_sell, handle_swap,
 };
 use crate::state::ServiceState;
 use crate::util::{env, healthz};
@@ -48,16 +48,10 @@ impl ListenService {
         HttpServer::new(move || {
             App::new()
                 .app_data(Data::new(state.clone()))
-                // Buy endpoints
-                .service(handle_buy)
-                // Sell endpoints
-                .service(handle_sell)
+                .service(handle_swap)
                 .service(handle_balance)
-                // Pump endpoints
                 .service(handle_pump_buy)
                 .service(handle_pump_sell)
-                // Check endpoints
-                // Health check
                 .service(healthz)
         })
         .bind(("0.0.0.0", self.port))?


### PR DESCRIPTION
- Consolidated buy/sell endpoints into a single `/swap` endpoint using Jupiter
- Implemented pump buy/sell functionality with Jito transaction submission
- Simplified error handling and removed redundant error wrapping
- Added Jito transaction response parsing and improved logging
- Removed unused state parameter from pricing handler
- Updated service routes and cleaned up endpoint organization

