### PR TITLE
fix: unwrap/expect panics in buyer/seller logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,5 +73,5 @@ hyper-util = "0.1.7"
 http-body-util = "0.1.2"
 
 [lints.clippy]
-unwrap_used = "warn"
-expect_used = "warn"
+# unwrap_used = "warn"
+# expect_used = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ hyper = { version = "1.4.1", features = ["full"] }
 tokio-native-tls = "0.3.1"
 hyper-util = "0.1.7"
 http-body-util = "0.1.2"
+
+[lints.clippy]
+unwrap_used = "warn"
+expect_used = "warn"

--- a/src/orca.rs
+++ b/src/orca.rs
@@ -75,6 +75,7 @@ pub async fn get_whirpool(
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::constants::SOLANA_PROGRAM_ID;

--- a/src/pump.rs
+++ b/src/pump.rs
@@ -141,7 +141,7 @@ pub async fn get_tokens_held(
 ) -> Result<Vec<PumpTokenData>, Box<dyn Error>> {
     let url = format!(
         "https://frontend-api.pump.fun/balances/{}?limit=100&offset=0",
-        owner.to_string()
+        owner
     );
     Ok(reqwest::get(&url)
         .await?

--- a/src/pump.rs
+++ b/src/pump.rs
@@ -139,8 +139,10 @@ pub async fn mint_to_pump_accounts(
 pub async fn get_tokens_held(
     owner: &Pubkey,
 ) -> Result<Vec<PumpTokenData>, Box<dyn Error>> {
-    let url = "https://frontend-api.pump.fun/balances/{}?limit=100&offset=0";
-    let url = url.replace("{}", &owner.to_string());
+    let url = format!(
+        "https://frontend-api.pump.fun/balances/{}?limit=100&offset=0",
+        owner.to_string()
+    );
     Ok(reqwest::get(&url)
         .await?
         .json::<Vec<PumpTokenData>>()

--- a/src/seller_service.rs
+++ b/src/seller_service.rs
@@ -313,7 +313,7 @@ pub async fn load_amm_keys(
     )
     .await
     .map_err(|_| "Failed to get account")?
-    .ok_or_else(|| "Account not found")?;
+    .ok_or("Account not found")?;
 
     Ok(amm::AmmKeys {
         amm_pool: *amm_pool,

--- a/src/tx_parser.rs
+++ b/src/tx_parser.rs
@@ -34,7 +34,7 @@ pub fn parse_mint(
                         // TODO this might panic, might be handled more gracefully
                         let mint = ix.parsed["info"]["mint"]
                             .as_str()
-                            .unwrap()
+                            .ok_or("Failed to get string")?
                             .to_string();
                         return Ok(mint);
                     }
@@ -87,7 +87,7 @@ pub fn parse_notional(
         let max_sol = std::iter::zip(&meta.pre_balances, &meta.post_balances)
             .map(|(a, b)| (*a as f64 - *b as f64) as u64)
             .max()
-            .unwrap();
+            .ok_or("Failed to get max")?;
         return Ok(max_sol);
     }
     Err("could not parse notional".into())
@@ -121,9 +121,8 @@ pub fn parse_new_pool(
                         pool_info.amm_pool_id = Pubkey::from_str(
                             parsed_ix.parsed["info"]["account"]
                                 .as_str()
-                                .unwrap(),
-                        )
-                        .unwrap();
+                                .ok_or("Failed to get string")?,
+                        )?;
                     }
 
                     if parsed_ix.parsed["type"] == "initializeAccount"
@@ -131,14 +130,14 @@ pub fn parse_new_pool(
                             == constants::RAYDIUM_AUTHORITY_V4_PUBKEY
                                 .to_string()
                     {
-                        let mint =
-                            parsed_ix.parsed["info"]["mint"].as_str().unwrap();
+                        let mint = parsed_ix.parsed["info"]["mint"]
+                            .as_str()
+                            .ok_or("Failed to get string")?;
                         if mint == constants::SOLANA_PROGRAM_ID.to_string() {
                             pool_info.input_mint =
                                 constants::SOLANA_PROGRAM_ID;
                         } else {
-                            pool_info.output_mint =
-                                Pubkey::from_str(mint).unwrap();
+                            pool_info.output_mint = Pubkey::from_str(mint)?;
                         }
                     }
 
@@ -146,8 +145,7 @@ pub fn parse_new_pool(
                         if let Some(owner) =
                             parsed_ix.parsed["info"]["source"].as_str()
                         {
-                            pool_info.creator =
-                                Pubkey::from_str(owner).unwrap();
+                            pool_info.creator = Pubkey::from_str(owner)?;
                         }
                     }
                 }
@@ -178,9 +176,8 @@ pub fn parse_swap(
                         {
                             let amount = parsed_ix.parsed["info"]["amount"]
                                 .as_str()
-                                .unwrap()
-                                .parse::<f64>()
-                                .unwrap();
+                                .ok_or("Failed to get string")?
+                                .parse::<f64>()?;
                             // if the authority is raydium, it is the shitcoin, otherwise SOL
                             if parsed_ix.parsed["info"]["authority"]
                                 == constants::RAYDIUM_AUTHORITY_V4_PUBKEY

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -37,8 +37,7 @@ pub async fn _connect_to_websocket(
     let stream = TcpStream::connect(format!("{}:443", host)).await?;
 
     // Convert the TCP stream to a TLS stream
-    let tls_connector =
-        tokio_native_tls::native_tls::TlsConnector::new().unwrap();
+    let tls_connector = tokio_native_tls::native_tls::TlsConnector::new()?;
     let tls_connector = tokio_native_tls::TlsConnector::from(tls_connector);
     let tls_stream = tls_connector.connect(&host, stream).await?;
 


### PR DESCRIPTION
- `unwrap_used` & `expect_used` lints were added as warnings
- replace the majority of unwrap/expect panics in **buyer** related logic with  errors
- replace the majority of unwrap/expect panics in **seller** related logic with  errors
- small fixes in ws-transport initializing