### PR TITLE
CI for Rust 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,33 @@ on:
   push:
   pull_request:
 
+# Cancel in-progress workflows on branches, expect main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main')}}
+
+# TODO: Consider using composite actions to setup code duplication for each job
+# https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v4
+    - name: Set up cargo cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }} 
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3
+    - name: Lint
+      run: cargo clippy
   build:
     runs-on: ubuntu-latest
     steps:
@@ -22,11 +48,26 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }} 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
-    # TODO: Run lint, build, and tests in parallel to save time
-    - name: Lint
-      run: cargo clippy
     - name: Build
       run: cargo build
-    # Uncomment when tests are stable
-    # - name: Run tests
-    #   run: cargo test --lib
+  
+  # Uncomment when tests are stable
+  # test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Check out
+  #     uses: actions/checkout@v4
+  #   - name: Set up cargo cache
+  #     uses: actions/cache@v4
+  #     with:
+  #       path: |
+  #         ~/.cargo/bin/
+  #         ~/.cargo/registry/index/
+  #         ~/.cargo/registry/cache/
+  #         ~/.cargo/git/db/
+  #         target/
+  #       key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }} 
+  #   - name: Install Protoc
+  #     uses: arduino/setup-protoc@v3
+  #   - name: Run tests
+  #     run: cargo test --lib

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,9 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }} 
-    # Github Runners already have Rust installed
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3
+    # TODO: Run lint, build, and tests in parallel to save time
     - name: Lint
       run: cargo clippy
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,30 @@
+name: Rust CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v4
+    - name: Set up cargo cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }} 
+    # Github Runners already have Rust installed
+    - name: Lint
+      run: cargo clippy
+    - name: Build
+      run: cargo build
+    # Uncomment when tests are stable
+    # - name: Run tests
+    #   run: cargo test --lib


### PR DESCRIPTION
## Issue
https://github.com/piotrostr/listen/issues/11

## Description
Adds a Github Workflow for Rust:
- Runs `cargo lint` and `cargo build` in parallel
- Caches cargo related things to speed up builds
- Cancels workflows that are in progress for new commits for all branches except `main` to avoid unnecessary resource usage

## Example
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/4f333153-186c-4fde-b5e3-e8a7b2496d59" />


Note: I've left `cargo test --lib`, because they require an RPC and I think a wallet? Maybe we could mock the responses for those tests that require external resources. At the moment, I did not feel confident enough to enable them in CI.