### PR TITLE
feat: http streaming service for rig agents

### DIFF
--- a/listen-kit/Cargo.lock
+++ b/listen-kit/Cargo.lock
@@ -13,6 +13,253 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-cors"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "ahash",
+ "base64 0.22.1",
+ "bitflags 2.8.0",
+ "brotli 6.0.0",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "actix-web-lab"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7675c1a84eec1b179c844cdea8488e3e409d8e4984026e92fa96c87dd86f33c6"
+dependencies = [
+ "actix-http",
+ "actix-router",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "actix-web-lab-derive",
+ "ahash",
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytestring",
+ "csv",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "impl-more",
+ "itertools 0.12.1",
+ "local-channel",
+ "mediatype",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "actix-web-lab-derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa0b287c8de4a76b691f29dbb5451e8dd5b79d777eaf87350c9b0cbfdb5e968"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +417,12 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "ark-bn254"
@@ -374,7 +627,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
 dependencies = [
- "brotli",
+ "brotli 7.0.0",
  "flate2",
  "futures-core",
  "memchr",
@@ -603,6 +856,17 @@ dependencies = [
 
 [[package]]
 name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
@@ -678,6 +942,15 @@ name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+
+[[package]]
+name = "bytestring"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "caps"
@@ -836,6 +1109,23 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1132,6 +1422,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2109,6 +2412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2636,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 name = "listen-kit"
 version = "0.3.0"
 dependencies = [
+ "actix-cors",
+ "actix-web",
+ "actix-web-lab",
  "anyhow",
  "base64 0.22.1",
  "bincode",
@@ -2329,6 +2647,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "futures",
+ "futures-util",
  "hex",
  "lazy_static",
  "log",
@@ -2352,6 +2671,7 @@ dependencies = [
  "thiserror 2.0.11",
  "timed",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2361,6 +2681,23 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "local-channel"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
@@ -2377,6 +2714,12 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "mediatype"
+version = "0.19.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878cd8d1b3c8c8ae4b2ba0a36652b7cf192f618a599a7fbdfa25cffd4ea72dd"
 
 [[package]]
 name = "memchr"
@@ -2452,6 +2795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -3153,6 +3497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +4001,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2de91cf02bbc07cde38891769ccd5d4f073d22a40683aa4bc7a95781aaa2c4"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.7.1",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/listen-kit/Cargo.toml
+++ b/listen-kit/Cargo.toml
@@ -6,7 +6,18 @@ license = "MIT"
 description = "Blockchain actions for AI agents"
 documentation = "https://docs.listen-rs.com"
 
+[features]
+default = ["http"]
+http = [
+  "actix-web",
+  "actix-cors",
+  "actix-web-lab",
+  "futures-util",
+  "tokio-stream",
+]
+
 [dependencies]
+# Core dependencies
 env_logger = "0.11.6"
 log = "0.4.25"
 solana-account-decoder = "2.1.9"
@@ -32,9 +43,7 @@ proc-macro2 = "1.0.93"
 quote = "1.0.38"
 syn = { version = "1.0", features = ["full"] }
 anyhow = "1.0.95"
-# temporarily use the git version until the next release
 rig-core = { version = "0.6.1", git = "https://github.com/piotrostr/rig", branch = "feat/anthropic-streaming-api" }
-# rig-core = { path = "../../rig/rig-core" }
 once_cell = "1.20.2"
 rig-tool-macro = "0.2.0"
 thiserror = "2.0.11"
@@ -42,3 +51,9 @@ tracing-subscriber = "0.3.19"
 tracing = "0.1.41"
 lazy_static = "1.5.0"
 futures = "0.3.31"
+
+actix-web = { version = "4", optional = true }
+actix-cors = { version = "0.6", optional = true }
+actix-web-lab = { version = "0.20", optional = true }
+futures-util = { version = "0.3", optional = true }
+tokio-stream = { version = "0.1.17", optional = true }

--- a/listen-kit/scripts/send-test-req.sh
+++ b/listen-kit/scripts/send-test-req.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+curl -X POST http://localhost:8080/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "What is the public key of your wallet?",
+    "chat_history": []
+  }'
+

--- a/listen-kit/src/bin/server.rs
+++ b/listen-kit/src/bin/server.rs
@@ -1,0 +1,22 @@
+#[cfg(feature = "http")]
+use listen_kit::http::run_server;
+
+#[cfg(feature = "http")]
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    use listen_kit::agent::create_trader_agent;
+
+    dotenv::dotenv().ok();
+    tracing_subscriber::fmt::init();
+
+    let agent = create_trader_agent()
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    run_server(agent).await
+}
+
+#[cfg(not(feature = "http"))]
+fn main() {
+    println!("This binary requires the 'http' feature");
+}

--- a/listen-kit/src/http/mod.rs
+++ b/listen-kit/src/http/mod.rs
@@ -1,0 +1,130 @@
+#[cfg(feature = "http")]
+use {
+    actix_cors::Cors,
+    actix_web::{get, post, web, App, HttpServer, Responder},
+    actix_web_lab::sse,
+    futures_util::StreamExt,
+    rig::agent::Agent,
+    rig::completion::Message,
+    rig::providers::anthropic::completion::CompletionModel,
+    rig::streaming::{StreamingChat, StreamingChoice},
+    serde::{Deserialize, Serialize},
+    serde_json::json,
+    std::sync::Arc,
+    std::time::Duration,
+};
+
+#[cfg(feature = "http")]
+#[derive(Deserialize)]
+pub struct ChatRequest {
+    prompt: String,
+    chat_history: Vec<Message>,
+}
+
+#[cfg(feature = "http")]
+#[derive(Serialize)]
+#[serde(tag = "type", content = "content")]
+pub enum StreamResponse {
+    Message(String),
+    ToolCall { name: String, result: String },
+    Error(String),
+}
+
+#[cfg(feature = "http")]
+pub struct AppState {
+    agent: Arc<Agent<CompletionModel>>,
+}
+
+#[cfg(feature = "http")]
+#[post("/stream")]
+async fn stream(
+    state: web::Data<AppState>,
+    request: web::Json<ChatRequest>,
+) -> impl Responder {
+    let (tx, rx) = tokio::sync::mpsc::channel::<sse::Event>(32);
+    let agent = state.agent.clone();
+    let prompt = request.prompt.clone();
+    let messages = request.chat_history.clone();
+
+    tokio::spawn(async move {
+        let mut stream = match agent.stream_chat(&prompt, messages).await {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = tx
+                    .send(sse::Event::Data(sse::Data::new(
+                        serde_json::to_string(&StreamResponse::Error(
+                            e.to_string(),
+                        ))
+                        .unwrap(),
+                    )))
+                    .await;
+                return;
+            }
+        };
+
+        while let Some(chunk) = stream.next().await {
+            let response = match chunk {
+                Ok(StreamingChoice::Message(text)) => {
+                    StreamResponse::Message(text)
+                }
+                Ok(StreamingChoice::ToolCall(name, _, params)) => {
+                    match agent.tools.call(&name, params.to_string()).await {
+                        Ok(result) => StreamResponse::ToolCall {
+                            name: name.to_string(),
+                            result: result.to_string(),
+                        },
+                        Err(e) => StreamResponse::Error(format!(
+                            "Tool call failed: {}",
+                            e
+                        )),
+                    }
+                }
+                Err(e) => StreamResponse::Error(e.to_string()),
+            };
+
+            if tx
+                .send(sse::Event::Data(sse::Data::new(
+                    serde_json::to_string(&response).unwrap(),
+                )))
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    sse::Sse::from_infallible_receiver(rx)
+        .with_keep_alive(Duration::from_secs(15))
+        .with_retry_duration(Duration::from_secs(10))
+}
+
+#[cfg(feature = "http")]
+#[get("/health")]
+async fn health_check() -> impl Responder {
+    web::Json(json!({
+        "status": "ok",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    }))
+}
+
+#[cfg(feature = "http")]
+pub async fn run_server(agent: Agent<CompletionModel>) -> std::io::Result<()> {
+    use actix_web::middleware::{Compress, Logger};
+
+    let state = web::Data::new(AppState {
+        agent: Arc::new(agent),
+    });
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Logger::default())
+            .wrap(Compress::default())
+            .wrap(Cors::permissive())
+            .app_data(state.clone())
+            .service(stream)
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}

--- a/listen-kit/src/lib.rs
+++ b/listen-kit/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg(feature = "http")]
+pub mod http;
+
 pub mod agent;
 pub mod balance;
 pub mod blockhash;


### PR DESCRIPTION
HTTP Server with SSE Streaming Support

Spawn a listen-kit instance as a backend for your web-app

- Added optional `http` feature flag with actix-web dependencies
- Implemented streaming chat endpoint with SSE support
- Added tiny test script

Usage:
```bash
# Run server
cargo run --bin server --features http

# Test streaming endpoint
./scripts/send-test-req.sh
```

Dependencies added:
- actix-web v4
- actix-cors v0.6
- actix-web-lab v0.20
- futures-util
- tokio-stream
