### PR TITLE
Extended Pump.functionality

### DIFF
--- a/listen-kit/Cargo.toml
+++ b/listen-kit/Cargo.toml
@@ -7,7 +7,7 @@ description = "Blockchain actions for AI agents"
 documentation = "https://docs.listen-rs.com"
 
 [features]
-default = ["http"]
+default = ["solana"]
 full = ["http", "solana", "evm"]
 http = [
   "actix-web",

--- a/listen-kit/src/signer/mod.rs
+++ b/listen-kit/src/signer/mod.rs
@@ -54,6 +54,17 @@ pub trait TransactionSigner: Send + Sync {
         ))
     }
 
+    #[cfg(feature = "solana")]
+    async fn sign_and_send_solana_transaction_with_tip(
+        &self,
+        _ix: &mut Vec<solana_sdk::instruction::Instruction>,
+        _tip_lamports: u64,
+    ) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "Solana instructions not supported by this signer"
+        ))
+    }
+
     #[cfg(feature = "evm")]
     async fn sign_and_send_evm_transaction(
         &self,

--- a/listen-kit/src/signer/solana.rs
+++ b/listen-kit/src/signer/solana.rs
@@ -2,10 +2,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
+use solana_sdk::transaction::Transaction;
 use std::sync::Arc;
 
 use crate::solana::blockhash::BLOCKHASH_CACHE;
-use crate::solana::transaction::send_tx;
+use crate::solana::transaction::{add_jito_tip, send_tx};
 
 use super::TransactionSigner;
 
@@ -41,5 +42,20 @@ impl TransactionSigner for LocalSolanaSigner {
         let recent_blockhash = BLOCKHASH_CACHE.get_blockhash().await?;
         tx.try_sign(&[&*self.keypair], recent_blockhash)?;
         send_tx(tx).await
+    }
+
+    async fn sign_and_send_solana_transaction_with_tip(
+        &self,
+        ix: &mut Vec<solana_sdk::instruction::Instruction>,
+        tip_lamports: u64,
+    ) -> Result<String> {
+        let recent_blockhash = BLOCKHASH_CACHE.get_blockhash().await?;
+
+        add_jito_tip(tip_lamports, ix, &self.keypair.pubkey());
+
+        let mut tx =
+            Transaction::new_with_payer(ix, Some(&self.keypair.pubkey()));
+        tx.try_sign(&[&*self.keypair], recent_blockhash)?;
+        send_tx(&tx).await
     }
 }

--- a/listen-kit/src/solana/balance.rs
+++ b/listen-kit/src/solana/balance.rs
@@ -58,3 +58,18 @@ pub async fn get_holdings(
 
     Ok(holdings)
 }
+
+// Get ata balance for an owner and mint
+pub async fn get_balance(
+    rpc_client: &RpcClient,
+    owner: &Pubkey,
+    mint: &Pubkey,
+) -> Result<String> {
+    let token_account =
+        spl_associated_token_account::get_associated_token_address(
+            &owner, &mint,
+        );
+    tracing::info!("token account: {}", token_account);
+    let ata = rpc_client.get_token_account_balance(&token_account).await?;
+    Ok(ata.amount)
+}

--- a/listen-kit/src/solana/trade_pump.rs
+++ b/listen-kit/src/solana/trade_pump.rs
@@ -4,6 +4,7 @@ use crate::solana::pump::{
 };
 use anyhow::Result;
 use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::transaction::Transaction;
 use std::str::FromStr;
@@ -13,13 +14,13 @@ fn apply_slippage(amount: u64, slippage_bps: u16) -> u64 {
     amount - slippage
 }
 
-pub async fn create_buy_pump_fun_tx(
+pub async fn create_buy_pump_fun_ix(
     mint: String,
     sol_amount: u64,
     slippage_bps: u16,
     rpc_client: &RpcClient,
     owner: &Pubkey,
-) -> Result<Transaction> {
+) -> Result<Vec<Instruction>> {
     let mint = Pubkey::from_str(&mint)?;
     let pump_accounts = mint_to_pump_accounts(&mint);
 
@@ -41,16 +42,34 @@ pub async fn create_buy_pump_fun_tx(
         sol_amount,
     )?;
 
+    Ok(buy_ixs)
+}
+
+pub async fn create_buy_pump_fun_tx(
+    mint: String,
+    sol_amount: u64,
+    slippage_bps: u16,
+    rpc_client: &RpcClient,
+    owner: &Pubkey,
+) -> Result<Transaction> {
+    let buy_ixs = create_buy_pump_fun_ix(
+        mint,
+        sol_amount,
+        slippage_bps,
+        rpc_client,
+        owner,
+    )
+    .await?;
     let tx = Transaction::new_with_payer(buy_ixs.as_slice(), Some(owner));
 
     Ok(tx)
 }
 
-pub async fn create_sell_pump_fun_tx(
+pub async fn create_sell_pump_fun_ix(
     mint: String,
     token_amount: u64,
     owner: &Pubkey,
-) -> Result<Transaction> {
+) -> Result<Vec<Instruction>> {
     let mint = Pubkey::from_str(&mint)?;
     let pump_accounts = mint_to_pump_accounts(&mint);
 
@@ -61,7 +80,16 @@ pub async fn create_sell_pump_fun_tx(
 
     let ix = make_pump_sell_ix(*owner, pump_accounts, token_amount, ata)?;
 
-    let tx = Transaction::new_with_payer([ix].as_slice(), Some(owner));
+    Ok(vec![ix])
+}
+
+pub async fn create_sell_pump_fun_tx(
+    mint: String,
+    token_amount: u64,
+    owner: &Pubkey,
+) -> Result<Transaction> {
+    let ix = create_sell_pump_fun_ix(mint, token_amount, owner).await?;
+    let tx = Transaction::new_with_payer(ix.as_slice(), Some(owner));
 
     Ok(tx)
 }

--- a/listen-kit/src/solana/transaction.rs
+++ b/listen-kit/src/solana/transaction.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use rand::rngs::ThreadRng;
 use rand::thread_rng;
 use rand::Rng;
-use serde::Deserialize;
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcSendTransactionConfig;
@@ -17,6 +16,10 @@ use std::str::FromStr;
 use tracing::info;
 
 use crate::solana::util::env;
+
+use solana_sdk::system_instruction;
+
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct JitoResponse {
@@ -131,6 +134,20 @@ pub fn get_jito_tip_pubkey() -> Pubkey {
     ];
     let index = fast_random_0_to_7();
     Pubkey::from_str(PUBKEYS[index as usize]).expect("parse tip pubkey")
+}
+
+/// Adds a Jito tip instruction to a transaction
+#[inline]
+pub fn add_jito_tip(
+    tip_lamports: u64,
+    instructions: &mut Vec<solana_sdk::instruction::Instruction>,
+    payer: &Pubkey,
+) {
+    instructions.push(system_instruction::transfer(
+        payer,
+        &get_jito_tip_pubkey(),
+        tip_lamports,
+    ));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Extended Pump.fun functionality by:
* changing `trade_pump` to offer methods for generating just the instructions and not the whole tx
* added a new method to the Solana signer `sign_and_send_solana_transaction_with_tip` to pass the Jito tip. (For this to work, the methods in trade_pump generating just the ixs were needed.)
* added a new method to get the balance of the token in `solana/balance`
* changed the default feature to "solana" to circumvent issue #56 