### PR TITLE
feat: follow-up prompts

### DIFF
--- a/listen-adapter/src/routes.rs
+++ b/listen-adapter/src/routes.rs
@@ -33,7 +33,7 @@ pub async fn health_check() -> HttpResponse {
 
 pub async fn version() -> HttpResponse {
     HttpResponse::Ok().json(json!({
-        "version": "2.6.1"
+        "version": "2.6.2"
     }))
 }
 

--- a/listen-adapter/src/routes.rs
+++ b/listen-adapter/src/routes.rs
@@ -33,7 +33,7 @@ pub async fn health_check() -> HttpResponse {
 
 pub async fn version() -> HttpResponse {
     HttpResponse::Ok().json(json!({
-        "version": "2.5.0"
+        "version": "2.6.0"
     }))
 }
 

--- a/listen-adapter/src/routes.rs
+++ b/listen-adapter/src/routes.rs
@@ -33,7 +33,7 @@ pub async fn health_check() -> HttpResponse {
 
 pub async fn version() -> HttpResponse {
     HttpResponse::Ok().json(json!({
-        "version": "2.6.0"
+        "version": "2.6.1"
     }))
 }
 

--- a/listen-interface/src/components/Chat.tsx
+++ b/listen-interface/src/components/Chat.tsx
@@ -230,19 +230,6 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
               messages={messages}
             />
           ))}
-          {!isLoading && suggestions.length > 0 && (
-            <div className="flex flex-wrap gap-2 px-4 py-2 mt-2">
-              {suggestions.map((suggestion, index) => (
-                <button
-                  key={index}
-                  onClick={() => handleQuestionClick(suggestion.text)}
-                  className="bg-gray-700 hover:bg-gray-600 text-white rounded-full px-4 py-2 text-sm"
-                >
-                  {suggestion.text}
-                </button>
-              ))}
-            </div>
-          )}
           <div className="flex flex-row items-center gap-2 pl-3 mt-2">
             {isLoading && <ThinkingIndicator />}
             {isLoading && !toolBeingCalled && isLastMessageOutgoing && (

--- a/listen-interface/src/components/Chat.tsx
+++ b/listen-interface/src/components/Chat.tsx
@@ -203,11 +203,6 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
         i18n.language
       );
     }
-
-    // Cleanup function to clear suggestions when chat changes
-    return () => {
-      useSuggestStore.getState().clearSuggestions(urlParams.chatId);
-    };
   }, [
     urlParams.chatId,
     messages,
@@ -220,11 +215,7 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
 
   if (IS_DISABLED) {
     return (
-      <ChatContainer
-        inputMessage=""
-        isGenerating={false}
-        suggestions={suggestions}
-      >
+      <ChatContainer inputMessage="" isGenerating={false}>
         <div className="text-white px-4 py-2">disabled</div>
       </ChatContainer>
     );
@@ -243,7 +234,7 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
         handleQuestionClick={handleQuestionClick}
         displayTiles={messages.length === 0}
         hasMessages={messages.length > 0}
-        suggestions={suggestions}
+        chatId={urlParams.chatId}
       >
         <div className="h-full flex flex-col">
           {messages.length === 0 && (

--- a/listen-interface/src/components/Chat.tsx
+++ b/listen-interface/src/components/Chat.tsx
@@ -48,13 +48,17 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
     isLastMessageOutgoing,
   } = useChat();
 
-  const { suggestions, isLoading: isSuggestionsLoading } = useSuggestStore();
+  const {
+    suggestions,
+    isLoading: isSuggestionsLoading,
+    fetchSuggestions,
+  } = useSuggestStore();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [inputMessage, setInputMessage] = useState("");
   const { getAccessToken } = usePrivy();
   const [hasLoadedSharedChat, setHasLoadedSharedChat] = useState(false);
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { openShareModal } = useModal();
 
   const [toolBeingCalled, setToolBeingCalled] = useState<ToolCall | null>(null);
@@ -172,6 +176,18 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
       }
     }
   }, [messages]);
+
+  // Handle initial load suggestions
+  useEffect(() => {
+    if (
+      messages.length > 0 && // Has messages
+      !isLoading && // Not currently generating
+      !isSuggestionsLoading && // Not already fetching suggestions
+      suggestions.length === 0 // No existing suggestions
+    ) {
+      fetchSuggestions(messages, getAccessToken, i18n.language);
+    }
+  }, [messages, isLoading, isSuggestionsLoading, suggestions.length]);
 
   if (IS_DISABLED) {
     return (

--- a/listen-interface/src/components/Chat.tsx
+++ b/listen-interface/src/components/Chat.tsx
@@ -183,7 +183,8 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
       messages.length > 0 && // Has messages
       !isLoading && // Not currently generating
       !isSuggestionsLoading && // Not already fetching suggestions
-      suggestions.length === 0 // No existing suggestions
+      suggestions.length === 0 && // No existing suggestions
+      !useSuggestStore.getState().hasFailedForMessage // Haven't failed for this message
     ) {
       fetchSuggestions(messages, getAccessToken, i18n.language);
     }

--- a/listen-interface/src/components/Chat.tsx
+++ b/listen-interface/src/components/Chat.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useChat } from "../contexts/ChatContext";
 import { useModal } from "../contexts/ModalContext";
+import { useSuggestStore } from "../store/suggestStore";
 import { ToolCall, ToolCallSchema } from "../types/message";
 import { ChatContainer } from "./ChatContainer";
 import { MessageRenderer } from "./MessageRenderer";
@@ -46,6 +47,8 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
     isSharedChat,
     isLastMessageOutgoing,
   } = useChat();
+
+  const { suggestions, isLoading: isSuggestionsLoading } = useSuggestStore();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [inputMessage, setInputMessage] = useState("");
@@ -210,6 +213,19 @@ export function Chat({ selectedChatId }: { selectedChatId?: string }) {
               messages={messages}
             />
           ))}
+          {!isLoading && suggestions.length > 0 && (
+            <div className="flex flex-wrap gap-2 px-4 py-2 mt-2">
+              {suggestions.map((suggestion, index) => (
+                <button
+                  key={index}
+                  onClick={() => handleQuestionClick(suggestion.text)}
+                  className="bg-gray-700 hover:bg-gray-600 text-white rounded-full px-4 py-2 text-sm"
+                >
+                  {suggestion.text}
+                </button>
+              ))}
+            </div>
+          )}
           <div className="flex flex-row items-center gap-2 pl-3 mt-2">
             {isLoading && <ThinkingIndicator />}
             {isLoading && !toolBeingCalled && isLastMessageOutgoing && (

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useSuggestStore } from "../store/suggestStore";
@@ -81,22 +82,31 @@ export function ChatContainer({
           onSelect={handleQuestionClick || (() => {})}
         />
       )}
-      {!isGenerating &&
-        handleQuestionClick &&
-        suggestions.length > 0 && ( // TODO style this
-          <div className="flex flex-wrap gap-2 px-4 py-2 mt-2">
+      {!isGenerating && handleQuestionClick && suggestions.length > 0 && (
+        <div className="w-full overflow-x-auto scrollbar-hide px-4 md:px-0">
+          <div className="flex flex-nowrap gap-3 pb-4 min-w-min md:flex md:justify-center pt-2">
             {suggestions.map((suggestion, index) => (
-              <button
+              <motion.div
                 key={index}
-                disabled={isGenerating}
-                onClick={() => handleQuestionClick(suggestion)}
-                className="bg-gray-700 hover:bg-gray-600 text-white rounded-full px-4 py-2 text-sm"
+                className="flex-none snap-start"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
               >
-                {suggestion}
-              </button>
+                <div
+                  onClick={() => handleQuestionClick(suggestion)}
+                  className="flex-row min-w-[160px] max-w-[300px] h-[55px] bg-transparent
+                             border border-[#2D2D2D] rounded-[20px] cursor-pointer 
+                             flex justify-center items-center p-4"
+                >
+                  <span className="font-space-grotesk text-sm text-white line-clamp-2 text-center">
+                    {suggestion}
+                  </span>
+                </div>
+              </motion.div>
             ))}
           </div>
-        )}
+        </div>
+      )}
       <div className="sticky bottom-0 left-0 right-0 bg-[#151518]/80 backdrop-blur-sm pb-2 px-4 lg:px-0 pt-3">
         <ChatInput
           inputMessage={inputMessage}

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -16,7 +16,6 @@ interface ChatContainerProps {
   handleQuestionClick?: (question: string) => void;
   displayTiles?: boolean;
   hasMessages?: boolean;
-  chatId?: string;
   suggestions: any[];
 }
 
@@ -32,7 +31,6 @@ export function ChatContainer({
   handleQuestionClick,
   displayTiles = false,
   hasMessages = false,
-  chatId,
   suggestions,
 }: ChatContainerProps) {
   const { t } = useTranslation();

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { useSuggestStore } from "../store/suggestStore";
 import { ChatInput } from "./ChatInput";
 import { NewChatTiles } from "./NewChatTiles";
 
@@ -58,6 +59,10 @@ export function ChatContainer({
     },
   ];
 
+  const { suggestions } = useSuggestStore();
+
+  console.log(suggestions);
+
   return (
     <div className="relative mx-auto flex h-full w-full max-w-3xl flex-col md:px-2">
       <div
@@ -76,6 +81,22 @@ export function ChatContainer({
           onSelect={handleQuestionClick || (() => {})}
         />
       )}
+      {!isGenerating &&
+        handleQuestionClick &&
+        suggestions.length > 0 && ( // TODO style this
+          <div className="flex flex-wrap gap-2 px-4 py-2 mt-2">
+            {suggestions.map((suggestion, index) => (
+              <button
+                key={index}
+                disabled={isGenerating}
+                onClick={() => handleQuestionClick(suggestion)}
+                className="bg-gray-700 hover:bg-gray-600 text-white rounded-full px-4 py-2 text-sm"
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        )}
       <div className="sticky bottom-0 left-0 right-0 bg-[#151518]/80 backdrop-blur-sm pb-2 px-4 lg:px-0 pt-3">
         <ChatInput
           inputMessage={inputMessage}

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { useSuggestStore } from "../store/suggestStore";
 import { ChatInput } from "./ChatInput";
 import { NewChatTiles } from "./NewChatTiles";
 import { SuggestionTiles } from "./SuggestionTiles";
@@ -16,7 +17,7 @@ interface ChatContainerProps {
   handleQuestionClick?: (question: string) => void;
   displayTiles?: boolean;
   hasMessages?: boolean;
-  suggestions: any[];
+  chatId?: string;
 }
 
 export function ChatContainer({
@@ -31,9 +32,11 @@ export function ChatContainer({
   handleQuestionClick,
   displayTiles = false,
   hasMessages = false,
-  suggestions,
+  chatId,
 }: ChatContainerProps) {
   const { t } = useTranslation();
+  const { getSuggestions } = useSuggestStore();
+  const suggestions = chatId ? getSuggestions(chatId) : [];
 
   const RECOMMENDED_QUESTIONS_TILES = [
     {

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,7 +1,5 @@
-import { motion } from "framer-motion";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { useSuggestStore } from "../store/suggestStore";
 import { ChatInput } from "./ChatInput";
 import { NewChatTiles } from "./NewChatTiles";
 
@@ -60,9 +58,7 @@ export function ChatContainer({
     },
   ];
 
-  const { suggestions } = useSuggestStore();
-
-  console.log(suggestions);
+  // const { suggestions } = useSuggestStore();
 
   return (
     <div className="relative mx-auto flex h-full w-full max-w-3xl flex-col md:px-2">
@@ -82,7 +78,7 @@ export function ChatContainer({
           onSelect={handleQuestionClick || (() => {})}
         />
       )}
-      {!isGenerating && handleQuestionClick && suggestions.length > 0 && (
+      {/*!isGenerating && handleQuestionClick && suggestions.length > 0 && (
         <div className="w-full overflow-x-auto scrollbar-hide px-4 md:px-0">
           <div className="flex flex-nowrap gap-3 pb-4 min-w-min md:flex md:justify-center pt-2">
             {suggestions.map((suggestion, index) => (
@@ -106,7 +102,7 @@ export function ChatContainer({
             ))}
           </div>
         </div>
-      )}
+      )}*/}
       <div className="sticky bottom-0 left-0 right-0 bg-[#151518]/80 backdrop-blur-sm pb-2 px-4 lg:px-0 pt-3">
         <ChatInput
           inputMessage={inputMessage}

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,5 +1,7 @@
+import { motion } from "framer-motion";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { useSuggestStore } from "../store/suggestStore";
 import { ChatInput } from "./ChatInput";
 import { NewChatTiles } from "./NewChatTiles";
 
@@ -30,6 +32,7 @@ export function ChatContainer({
   displayTiles = false,
   hasMessages = false,
 }: ChatContainerProps) {
+  const { suggestions } = useSuggestStore();
   const { t } = useTranslation();
   const RECOMMENDED_QUESTIONS_TILES = [
     {
@@ -58,8 +61,6 @@ export function ChatContainer({
     },
   ];
 
-  // const { suggestions } = useSuggestStore();
-
   return (
     <div className="relative mx-auto flex h-full w-full max-w-3xl flex-col md:px-2">
       <div
@@ -78,31 +79,34 @@ export function ChatContainer({
           onSelect={handleQuestionClick || (() => {})}
         />
       )}
-      {/*!isGenerating && handleQuestionClick && suggestions.length > 0 && (
-        <div className="w-full overflow-x-auto scrollbar-hide px-4 md:px-0">
-          <div className="flex flex-nowrap gap-3 pb-4 min-w-min md:flex md:justify-center pt-2">
-            {suggestions.map((suggestion, index) => (
-              <motion.div
-                key={index}
-                className="flex-none snap-start"
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-              >
-                <div
-                  onClick={() => handleQuestionClick(suggestion)}
-                  className="flex-row min-w-[160px] max-w-[300px] h-[55px] bg-transparent
-                             border border-[#2D2D2D] rounded-[20px] cursor-pointer 
-                             flex justify-center items-center p-4"
+      {!isGenerating &&
+        handleQuestionClick &&
+        suggestions.length > 0 &&
+        !displayTiles && (
+          <div className="w-full overflow-x-auto scrollbar-hide px-4 md:px-0">
+            <div className="flex flex-nowrap gap-3 pb-4 min-w-min md:flex md:justify-center pt-2">
+              {suggestions.map((suggestion, index) => (
+                <motion.div
+                  key={index}
+                  className="flex-none snap-start"
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
                 >
-                  <span className="font-space-grotesk text-sm text-white line-clamp-2 text-center">
-                    {suggestion}
-                  </span>
-                </div>
-              </motion.div>
-            ))}
+                  <div
+                    onClick={() => handleQuestionClick(suggestion)}
+                    className="flex-row min-w-[130px] max-w-[280px] h-[45px] bg-transparent
+                             border border-[#2D2D2D] rounded-[20px] cursor-pointer 
+                             flex justify-center items-center p-2"
+                  >
+                    <span className="font-space-grotesk text-xs text-white line-clamp-2 text-center">
+                      {suggestion}
+                    </span>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
           </div>
-        </div>
-      )}*/}
+        )}
       <div className="sticky bottom-0 left-0 right-0 bg-[#151518]/80 backdrop-blur-sm pb-2 px-4 lg:px-0 pt-3">
         <ChatInput
           inputMessage={inputMessage}

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,9 +1,9 @@
-import { motion } from "framer-motion";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useSuggestStore } from "../store/suggestStore";
 import { ChatInput } from "./ChatInput";
 import { NewChatTiles } from "./NewChatTiles";
+import { SuggestionTiles } from "./SuggestionTiles";
 
 interface ChatContainerProps {
   inputMessage: string;
@@ -17,6 +17,7 @@ interface ChatContainerProps {
   handleQuestionClick?: (question: string) => void;
   displayTiles?: boolean;
   hasMessages?: boolean;
+  chatId?: string;
 }
 
 export function ChatContainer({
@@ -31,9 +32,12 @@ export function ChatContainer({
   handleQuestionClick,
   displayTiles = false,
   hasMessages = false,
+  chatId,
 }: ChatContainerProps) {
-  const { suggestions } = useSuggestStore();
   const { t } = useTranslation();
+  const suggestions = useSuggestStore((state) =>
+    chatId ? state.getSuggestions(chatId) : []
+  );
   const RECOMMENDED_QUESTIONS_TILES = [
     {
       question: t("recommended_questions.what_actions_can_you_perform_for_me"),
@@ -83,29 +87,10 @@ export function ChatContainer({
         handleQuestionClick &&
         suggestions.length > 0 &&
         !displayTiles && (
-          <div className="w-full overflow-x-auto scrollbar-hide px-4 md:px-0">
-            <div className="flex flex-nowrap gap-3 pb-4 min-w-min md:flex md:justify-center pt-2">
-              {suggestions.map((suggestion, index) => (
-                <motion.div
-                  key={index}
-                  className="flex-none snap-start"
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                >
-                  <div
-                    onClick={() => handleQuestionClick(suggestion)}
-                    className="flex-row min-w-[130px] max-w-[280px] h-[45px] bg-transparent
-                             border border-[#2D2D2D] rounded-[20px] cursor-pointer 
-                             flex justify-center items-center p-2"
-                  >
-                    <span className="font-space-grotesk text-xs text-white line-clamp-2 text-center">
-                      {suggestion}
-                    </span>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
-          </div>
+          <SuggestionTiles
+            suggestions={suggestions}
+            handleQuestionClick={handleQuestionClick}
+          />
         )}
       <div className="sticky bottom-0 left-0 right-0 bg-[#151518]/80 backdrop-blur-sm pb-2 px-4 lg:px-0 pt-3">
         <ChatInput

--- a/listen-interface/src/components/ChatContainer.tsx
+++ b/listen-interface/src/components/ChatContainer.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { useSuggestStore } from "../store/suggestStore";
 import { ChatInput } from "./ChatInput";
 import { NewChatTiles } from "./NewChatTiles";
 import { SuggestionTiles } from "./SuggestionTiles";
@@ -18,6 +17,7 @@ interface ChatContainerProps {
   displayTiles?: boolean;
   hasMessages?: boolean;
   chatId?: string;
+  suggestions: any[];
 }
 
 export function ChatContainer({
@@ -33,11 +33,10 @@ export function ChatContainer({
   displayTiles = false,
   hasMessages = false,
   chatId,
+  suggestions,
 }: ChatContainerProps) {
   const { t } = useTranslation();
-  const suggestions = useSuggestStore((state) =>
-    chatId ? state.getSuggestions(chatId) : []
-  );
+
   const RECOMMENDED_QUESTIONS_TILES = [
     {
       question: t("recommended_questions.what_actions_can_you_perform_for_me"),

--- a/listen-interface/src/components/MessageRenderer.tsx
+++ b/listen-interface/src/components/MessageRenderer.tsx
@@ -84,6 +84,8 @@ export function MessageRendererBase({
   const { debugMode } = useSettingsStore();
   if (!msg.message) return null;
 
+  console.log(msg);
+
   // Check if this is the last user message
   const isLastUserMessage = (() => {
     if (msg.direction !== "outgoing") return false;

--- a/listen-interface/src/components/MessageRenderer.tsx
+++ b/listen-interface/src/components/MessageRenderer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { useSettingsStore } from "../store/settingsStore";
 import {
   ToolCallSchema,
@@ -84,7 +85,7 @@ export function MessageRendererBase({
   const { debugMode } = useSettingsStore();
   if (!msg.message) return null;
 
-  console.log(msg);
+  const { t } = useTranslation();
 
   // Check if this is the last user message
   const isLastUserMessage = (() => {
@@ -154,6 +155,15 @@ export function MessageRendererBase({
   if (hasSpecialTags) {
     // Process the message with all supported tags
     return processMessageWithAllTags(msg.message, msg);
+  }
+
+  if (msg.message.includes("String should match pattern '^[a-zA-Z0-9_-]+$'")) {
+    return (
+      <ChatMessage
+        message={t("tool_messages.switch_model_error")}
+        direction={msg.direction}
+      />
+    );
   }
 
   // Default case: render as a regular message

--- a/listen-interface/src/components/MessageRenderer.tsx
+++ b/listen-interface/src/components/MessageRenderer.tsx
@@ -82,10 +82,10 @@ export function MessageRendererBase({
   message: Message;
   messages: Message[];
 }) {
-  const { debugMode } = useSettingsStore();
   if (!msg.message) return null;
 
   const { t } = useTranslation();
+  const { debugMode } = useSettingsStore();
 
   // Check if this is the last user message
   const isLastUserMessage = (() => {

--- a/listen-interface/src/components/RecentChats.tsx
+++ b/listen-interface/src/components/RecentChats.tsx
@@ -79,6 +79,7 @@ export function RecentChats({ onItemClick }: { onItemClick?: () => void }) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { t } = useTranslation();
+  const [currentChatId, setCurrentChatId] = useState<string | null>(null);
 
   // Group chats by time periods
   const groupChatsByTimePeriod = (chats: Chat[]) => {
@@ -196,6 +197,11 @@ export function RecentChats({ onItemClick }: { onItemClick?: () => void }) {
       setIsDropdownOpen(false);
     };
   }, [setIsDropdownOpen]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setCurrentChatId(params.get("chatId"));
+  }, [window.location.search]);
 
   const selectChat = (chatId: string) => {
     navigate({ to: "/", search: { chatId }, replace: true });
@@ -337,11 +343,15 @@ export function RecentChats({ onItemClick }: { onItemClick?: () => void }) {
 
   // Helper function to render chat items
   function renderChatItem(chat: Chat) {
+    const isCurrentChat = chat.id === currentChatId;
+
     return (
       <div
         key={chat.id}
         onClick={() => selectChat(chat.id)}
-        className="relative flex items-center h-8 px-2 text-sm text-gray-300 hover:text-white hover:bg-[#212121] transition-colors cursor-pointer group rounded-lg"
+        className={`relative flex items-center h-8 px-2 text-sm text-gray-300 hover:text-white hover:bg-[#212121] transition-colors cursor-pointer group rounded-lg ${
+          isCurrentChat ? "bg-[#1a1a1a] text-white" : ""
+        }`}
       >
         <div className="flex-1 min-w-0">
           {editingChatId === chat.id ? (

--- a/listen-interface/src/components/Settings.tsx
+++ b/listen-interface/src/components/Settings.tsx
@@ -6,6 +6,32 @@ import { ConnectedAccounts } from "./ConnectedAccounts";
 import { ModelSelector } from "./ModelSelector";
 import { WalletAddresses } from "./WalletAddresses";
 
+const Toggle = ({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+}) => {
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="text-lg font-bold">{label}</h2>
+      <button
+        onClick={onChange}
+        className={`px-4 py-2 rounded-lg transition-colors ${
+          checked
+            ? "bg-green-500/30 text-green-300 hover:bg-green-500/40"
+            : "bg-gray-600/30 text-gray-400 hover:bg-gray-600/40"
+        }`}
+      >
+        {checked ? "Enabled" : "Disabled"}
+      </button>
+    </div>
+  );
+};
+
 export function Settings() {
   const { user } = usePrivy();
   const { chatType, setChatType, modelType, setModelType } = useSettingsStore();
@@ -16,6 +42,8 @@ export function Settings() {
     setAgentMode,
     debugMode,
     setDebugMode,
+    displaySuggestions,
+    setDisplaySuggestions,
   } = useSettingsStore();
 
   const { t } = useTranslation();
@@ -29,6 +57,11 @@ export function Settings() {
   // Handle agent mode toggle
   const handleAgentModeToggle = () => {
     setAgentMode(!agentMode);
+  };
+
+  // Handle display suggestions toggle
+  const handleDisplaySuggestionsToggle = () => {
+    setDisplaySuggestions(!displaySuggestions);
   };
 
   return (
@@ -59,21 +92,11 @@ export function Settings() {
         </p>
       </div>
 
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-bold mb-2 mt-4">
-          {t("settings.agent_mode")}
-        </h2>
-        <button
-          onClick={handleAgentModeToggle}
-          className={`px-4 py-2 rounded-lg transition-colors ${
-            agentMode
-              ? "bg-green-500/30 text-green-300 hover:bg-green-500/40"
-              : "bg-gray-600/30 text-gray-400 hover:bg-gray-600/40"
-          }`}
-        >
-          {agentMode ? t("settings.enabled") : t("settings.disabled")}
-        </button>
-      </div>
+      <Toggle
+        label={t("settings.agent_mode")}
+        checked={agentMode}
+        onChange={handleAgentModeToggle}
+      />
       <p className="text-xs text-gray-400 mt-2">
         {t("settings.agent_mode_enabled")}
       </p>
@@ -86,6 +109,12 @@ export function Settings() {
 
       <h2 className="text-lg font-bold mb-2 mt-4">{t("settings.model")}</h2>
       <ModelSelector selectedModel={modelType} onSelectModel={setModelType} />
+
+      <Toggle
+        label={t("settings.suggestions")}
+        checked={displaySuggestions}
+        onChange={handleDisplaySuggestionsToggle}
+      />
 
       <h2 className="text-lg font-bold mb-2 mt-4">
         {t("settings.connected_accounts")}

--- a/listen-interface/src/components/SuggestionTiles.tsx
+++ b/listen-interface/src/components/SuggestionTiles.tsx
@@ -1,0 +1,44 @@
+import { motion } from "framer-motion";
+
+const sanitizeSuggestion = (suggestion: string) => {
+  return suggestion
+    .replace(/^"|\s+"$/g, "") // Remove quotes
+    .replace(/^[-*•]\s+/g, "") // Remove bullet points and dashes
+    .replace(/^\d+[.)]?\s+/g, ""); // Remove numbered items like 1. or 1)
+};
+
+export const SuggestionTiles = ({
+  suggestions,
+  handleQuestionClick,
+}: {
+  suggestions: string[];
+  handleQuestionClick: (question: string) => void;
+}) => {
+  return (
+    <div className="w-full overflow-x-auto scrollbar-hide px-4 md:px-0">
+      <div className="flex flex-nowrap gap-3 pb-4 min-w-min md:flex md:justify-center pt-2">
+        {suggestions.map((suggestion, index) => (
+          <motion.div
+            key={index}
+            className="flex-none snap-start"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+          >
+            <div
+              onClick={() =>
+                handleQuestionClick(sanitizeSuggestion(suggestion))
+              }
+              className="flex-row min-w-[130px] max-w-[280px] h-[45px] bg-transparent
+                             border border-[#2D2D2D] rounded-[20px] cursor-pointer 
+                             flex justify-center items-center p-2"
+            >
+              <span className="font-space-grotesk text-xs text-white line-clamp-2 text-center">
+                {sanitizeSuggestion(suggestion)}
+              </span>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/listen-interface/src/components/ToolMessage.tsx
+++ b/listen-interface/src/components/ToolMessage.tsx
@@ -471,10 +471,14 @@ export const ToolMessage = ({
       );
     }
   }
-  // Default tool output display
-  return (
-    <div className="text-blue-300 rounded-lg px-4 py-3 my-2 backdrop-blur-sm border border-opacity-20 border-blue-500 overflow-hidden">
-      <ChatMessage message={toolOutput.result} direction="incoming" />
-    </div>
-  );
+
+  if (toolOutput.result.includes("ToolCallError")) {
+    return (
+      <div className="text-red-400 flex items-center gap-1 p-3 text-sm">
+        <FaExclamationTriangle /> {t("tool_messages.tool_call_error")}
+      </div>
+    );
+  }
+
+  return <ChatMessage message={toolOutput.result} direction="incoming" />;
 };

--- a/listen-interface/src/contexts/ChatContext.tsx
+++ b/listen-interface/src/contexts/ChatContext.tsx
@@ -18,6 +18,7 @@ import i18n from "../i18n";
 import { pickSystemPrompt } from "../prompts";
 import { usePortfolioStore } from "../store/portfolioStore";
 import { useSettingsStore } from "../store/settingsStore";
+import { useSuggestStore } from "../store/suggestStore";
 import {
   Chat,
   Message,
@@ -58,6 +59,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const navigate = useNavigate();
   const { data: wallets, isLoading: isLoadingWallets } = usePrivyWallets();
   const { getSolanaAssets, getEvmAssets } = usePortfolioStore();
+  const { fetchSuggestions } = useSuggestStore();
 
   const solanaAssets = getSolanaAssets();
   const evmAssets = getEvmAssets();
@@ -398,6 +400,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
       wallets,
       chatType,
       navigate,
+      fetchSuggestions,
     ]
   );
 

--- a/listen-interface/src/contexts/ChatContext.tsx
+++ b/listen-interface/src/contexts/ChatContext.tsx
@@ -18,6 +18,7 @@ import i18n from "../i18n";
 import { pickSystemPrompt } from "../prompts";
 import { usePortfolioStore } from "../store/portfolioStore";
 import { useSettingsStore } from "../store/settingsStore";
+import { useSuggestStore } from "../store/suggestStore";
 import {
   Chat,
   Message,
@@ -128,7 +129,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
       options?: { skipAddingUserMessage?: boolean; existingMessageId?: string }
     ) => {
       // Clear suggestions when starting a new message
-      // useSuggestStore.getState().clearSuggestions();
+      useSuggestStore.getState().clearSuggestions(chatId);
 
       setIsLoading(true);
 

--- a/listen-interface/src/contexts/ChatContext.tsx
+++ b/listen-interface/src/contexts/ChatContext.tsx
@@ -18,7 +18,6 @@ import i18n from "../i18n";
 import { pickSystemPrompt } from "../prompts";
 import { usePortfolioStore } from "../store/portfolioStore";
 import { useSettingsStore } from "../store/settingsStore";
-import { useSuggestStore } from "../store/suggestStore";
 import {
   Chat,
   Message,
@@ -129,7 +128,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
       options?: { skipAddingUserMessage?: boolean; existingMessageId?: string }
     ) => {
       // Clear suggestions when starting a new message
-      useSuggestStore.getState().clearSuggestions();
+      // useSuggestStore.getState().clearSuggestions();
 
       setIsLoading(true);
 

--- a/listen-interface/src/contexts/ChatContext.tsx
+++ b/listen-interface/src/contexts/ChatContext.tsx
@@ -59,7 +59,6 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const navigate = useNavigate();
   const { data: wallets, isLoading: isLoadingWallets } = usePrivyWallets();
   const { getSolanaAssets, getEvmAssets } = usePortfolioStore();
-  const { fetchSuggestions } = useSuggestStore();
 
   const solanaAssets = getSolanaAssets();
   const evmAssets = getEvmAssets();
@@ -273,17 +272,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
 
         while (true) {
           const { done, value } = await reader.read();
-          if (done) {
-            // After message generation is complete, fetch suggestions
-            await useSuggestStore
-              .getState()
-              .fetchSuggestions(
-                chat?.messages || [],
-                getAccessToken,
-                i18n.language
-              );
-            break;
-          }
+          if (done) break;
 
           const chunk = decoder.decode(value);
           const messages = jsonReader.append(chunk);
@@ -413,7 +402,6 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
       wallets,
       chatType,
       navigate,
-      fetchSuggestions,
     ]
   );
 

--- a/listen-interface/src/i18n/translations/settings.ts
+++ b/listen-interface/src/i18n/translations/settings.ts
@@ -17,6 +17,7 @@ export const settings = {
     agent_mode_disabled:
       "Every trade is confirmed by hand. Listen doesn't have access to direct swapping tools.",
     model: "Model",
+    suggestions: "Suggestions",
   },
   zh: {
     title: "设置",
@@ -34,5 +35,6 @@ export const settings = {
     agent_mode_disabled:
       "每次交易都需要手动确认。Listen 没有访问直接交换工具的权限。",
     model: "模型",
+    suggestions: "建议",
   },
 };

--- a/listen-interface/src/i18n/translations/tool-messages.ts
+++ b/listen-interface/src/i18n/translations/tool-messages.ts
@@ -9,6 +9,7 @@ export const toolMessages = {
     analyze_page_content: "Page Analysis",
     search_tweets: "Search Results",
     search_web: "Web Search Results",
+    tool_call_error: "Tool call error",
   },
   zh: {
     account_suspended: "账户被暂停",
@@ -20,5 +21,6 @@ export const toolMessages = {
     analyze_page_content: "页面分析",
     search_tweets: "搜索结果",
     search_web: "网页搜索结果",
+    tool_call_error: "工具调用错误",
   },
 };

--- a/listen-interface/src/i18n/translations/tool-messages.ts
+++ b/listen-interface/src/i18n/translations/tool-messages.ts
@@ -10,6 +10,8 @@ export const toolMessages = {
     search_tweets: "Search Results",
     search_web: "Web Search Results",
     tool_call_error: "Tool call error",
+    switch_model_error:
+      "It is not possible to switch from Gemini to Claude in an ongoing chat. Please start a new chat.",
   },
   zh: {
     account_suspended: "账户被暂停",
@@ -22,5 +24,7 @@ export const toolMessages = {
     search_tweets: "搜索结果",
     search_web: "网页搜索结果",
     tool_call_error: "工具调用错误",
+    switch_model_error:
+      "无法在正在进行中的聊天中途从Gemini切换到Claude。请开始新的聊天。",
   },
 };

--- a/listen-interface/src/prompts/pipelines.ts
+++ b/listen-interface/src/prompts/pipelines.ts
@@ -34,7 +34,7 @@ const pipelineSchemaEvm = `
   const PipelineConditionSchema = z.object({
     type: z.nativeEnum(PipelineConditionType),
     asset: z.string(), // address or mint
-    value: z.number(), // Now can take any value, its not used
+    value: z.number(), // price denoted in usd, if \"Now\" type, price is not used
   });
 
   const PipelineStepSchema = z.object({
@@ -81,7 +81,7 @@ const pipelineSchemaSolana = `
   const PipelineConditionSchema = z.object({
     type: z.nativeEnum(PipelineConditionType),
     asset: z.string(), // address or mint
-    value: z.number(), // Now can take any value, its not used
+    value: z.number(), // price denoted in usd, if \"Now\" type, price is not used
   });
 
   const PipelineStepSchema = z.object({
@@ -101,5 +101,5 @@ export const pipelineKnowledge = (chain: "evm" | "solana") => `
   ${chain === "evm" ? pipelineSchemaEvm : pipelineSchemaSolana}
   When generating a pipeline, put it into <pipeline></pipeline> tags
   If any step is to be executed immediately, don't include the "conditions" key, it will be filled automatically
-  Always include the tags! Otherwise the pipeline will neither be rendered for the user to see nor executed
+  Always include the <pipeline></pipeline> tags! Otherwise the pipeline will neither be rendered
 `;

--- a/listen-interface/src/prompts/solana.ts
+++ b/listen-interface/src/prompts/solana.ts
@@ -25,9 +25,7 @@ export function systemPromptSolana(
 ) {
   const hasWallet = pubkey !== null && pubkey !== "";
   return `
-  <personality>
   ${personality}
-  </personality>
   <guidelines>${guidelines("solana", defaultAmount)}</guidelines>
   <research_flow>${researchFlow}</research_flow>
   ${!hasWallet || isGuest ? `<onboarding>${onboarding(hasWallet, isGuest, "solana")}</onboarding>` : ""}
@@ -48,7 +46,7 @@ export function systemPromptSolanaAgent(
 ) {
   const hasWallet = pubkey !== null && pubkey !== "";
   return `
-  <personality>${personalityAgent}</personality>
+  ${personalityAgent}
   <research_flow>${researchFlow}</research_flow>
   <guidelines>${guidelines("solana", defaultAmount)}</guidelines>
   ${!hasWallet || isGuest ? `<onboarding>${onboarding(hasWallet, isGuest, "solana")}</onboarding>` : ""}

--- a/listen-interface/src/store/settingsStore.ts
+++ b/listen-interface/src/store/settingsStore.ts
@@ -10,11 +10,13 @@ interface SettingsState {
   chatType: ChatType;
   debugMode: boolean;
   modelType: ModelType;
+  displaySuggestions: boolean;
   setQuickBuyAmount: (amount: number) => void;
   setAgentMode: (enabled: boolean) => void;
   setChatType: (type: ChatType) => void;
   setDebugMode: (enabled: boolean) => void;
   setModelType: (type: ModelType) => void;
+  setDisplaySuggestions: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -25,6 +27,7 @@ export const useSettingsStore = create<SettingsState>()(
       chatType: "solana" as ChatType,
       debugMode: false,
       modelType: "claude" as ModelType,
+      displaySuggestions: false,
 
       setQuickBuyAmount: (amount: number) => {
         if (!isNaN(amount) && amount > 0) {
@@ -46,6 +49,10 @@ export const useSettingsStore = create<SettingsState>()(
 
       setModelType: (type: ModelType) => {
         set({ modelType: type });
+      },
+
+      setDisplaySuggestions: (enabled: boolean) => {
+        set({ displaySuggestions: enabled });
       },
     }),
     {

--- a/listen-interface/src/store/suggestStore.ts
+++ b/listen-interface/src/store/suggestStore.ts
@@ -1,12 +1,8 @@
 import { create } from "zustand";
 import { Message } from "../types/message";
 
-interface Suggestion {
-  text: string;
-}
-
 interface SuggestState {
-  suggestions: Suggestion[];
+  suggestions: string[];
   isLoading: boolean;
   error: string | null;
   lastMessageId: string | null;
@@ -46,6 +42,11 @@ export const useSuggestStore = create<SuggestState>((set, get) => ({
 
     set({ isLoading: true, error: null });
 
+    const chatHistory = messages.map((msg) => ({
+      role: msg.direction === "outgoing" ? "user" : "assistant",
+      content: msg.message,
+    }));
+
     const attemptFetch = async (attempt: number): Promise<void> => {
       try {
         const token = await getAccessToken();
@@ -60,7 +61,7 @@ export const useSuggestStore = create<SuggestState>((set, get) => ({
               Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify({
-              chat_history: messages,
+              chat_history: chatHistory,
               locale,
             }),
           }

--- a/listen-interface/src/store/suggestStore.ts
+++ b/listen-interface/src/store/suggestStore.ts
@@ -9,22 +9,30 @@ interface SuggestState {
   suggestions: Suggestion[];
   isLoading: boolean;
   error: string | null;
+  lastMessageId: string | null;
   fetchSuggestions: (
-    chatHistory: Message[],
-    getAccessToken: () => Promise<string>,
+    messages: Message[],
+    getAccessToken: () => Promise<string | null>,
     locale?: string
   ) => Promise<void>;
+  clearSuggestions: () => void;
 }
 
 export const useSuggestStore = create<SuggestState>((set) => ({
   suggestions: [],
   isLoading: false,
   error: null,
-  fetchSuggestions: async (
-    chatHistory: Message[],
-    getAccessToken: () => Promise<string>,
-    locale = "en"
-  ) => {
+  lastMessageId: null,
+  fetchSuggestions: async (messages, getAccessToken, locale = "en") => {
+    if (messages.length === 0) return;
+
+    const lastMessage = messages[messages.length - 1];
+
+    // Don't refetch if we already have suggestions for this message
+    if (lastMessage.id === useSuggestStore.getState().lastMessageId) {
+      return;
+    }
+
     set({ isLoading: true, error: null });
     try {
       const token = await getAccessToken();
@@ -39,7 +47,7 @@ export const useSuggestStore = create<SuggestState>((set) => ({
             Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({
-            chat_history: chatHistory,
+            chat_history: messages,
             locale,
           }),
         }
@@ -50,7 +58,11 @@ export const useSuggestStore = create<SuggestState>((set) => ({
       }
 
       const data = await response.json();
-      set({ suggestions: data.suggestions, isLoading: false });
+      set({
+        suggestions: data.suggestions,
+        isLoading: false,
+        lastMessageId: lastMessage.id,
+      });
     } catch (error) {
       set({
         error: error instanceof Error ? error.message : "Unknown error",
@@ -58,4 +70,5 @@ export const useSuggestStore = create<SuggestState>((set) => ({
       });
     }
   },
+  clearSuggestions: () => set({ suggestions: [], lastMessageId: null }),
 }));

--- a/listen-interface/src/store/suggestStore.ts
+++ b/listen-interface/src/store/suggestStore.ts
@@ -10,6 +10,8 @@ interface SuggestState {
   isLoading: boolean;
   error: string | null;
   lastMessageId: string | null;
+  retryCount: number;
+  hasFailedForMessage: string | null;
   fetchSuggestions: (
     messages: Message[],
     getAccessToken: () => Promise<string | null>,
@@ -18,57 +20,92 @@ interface SuggestState {
   clearSuggestions: () => void;
 }
 
-export const useSuggestStore = create<SuggestState>((set) => ({
+const MAX_RETRIES = 3;
+const RETRY_DELAY = 1000; // 1 second
+
+export const useSuggestStore = create<SuggestState>((set, get) => ({
   suggestions: [],
   isLoading: false,
   error: null,
   lastMessageId: null,
+  retryCount: 0,
+  hasFailedForMessage: null,
   fetchSuggestions: async (messages, getAccessToken, locale = "en") => {
     if (messages.length === 0) return;
 
     const lastMessage = messages[messages.length - 1];
 
     // Don't refetch if we already have suggestions for this message
-    if (lastMessage.id === useSuggestStore.getState().lastMessageId) {
+    // or if we've already failed for this message
+    if (
+      lastMessage.id === get().lastMessageId ||
+      lastMessage.id === get().hasFailedForMessage
+    ) {
       return;
     }
 
     set({ isLoading: true, error: null });
-    try {
-      const token = await getAccessToken();
-      const response = await fetch(
-        process.env.NODE_ENV === "production"
-          ? "https://api.listen-rs.com/v1/suggest"
-          : "http://localhost:6969/suggest",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            chat_history: messages,
-            locale,
-          }),
+
+    const attemptFetch = async (attempt: number): Promise<void> => {
+      try {
+        const token = await getAccessToken();
+        const response = await fetch(
+          process.env.NODE_ENV === "production"
+            ? "https://api.listen-rs.com/v1/suggest"
+            : "http://localhost:6969/suggest",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+              chat_history: messages,
+              locale,
+            }),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch suggestions");
         }
-      );
 
-      if (!response.ok) {
-        throw new Error("Failed to fetch suggestions");
+        const data = await response.json();
+        set({
+          suggestions: data.suggestions,
+          isLoading: false,
+          lastMessageId: lastMessage.id,
+          retryCount: 0,
+          hasFailedForMessage: null,
+        });
+      } catch (error) {
+        if (attempt < MAX_RETRIES) {
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY));
+          return attemptFetch(attempt + 1);
+        }
+
+        // If all retries failed, mark this message as failed
+        set({
+          error: error instanceof Error ? error.message : "Unknown error",
+          isLoading: false,
+          retryCount: 0,
+          hasFailedForMessage: lastMessage.id,
+        });
+        console.error(
+          `Failed to fetch suggestions after ${MAX_RETRIES} attempts:`,
+          error
+        );
       }
+    };
 
-      const data = await response.json();
-      set({
-        suggestions: data.suggestions,
-        isLoading: false,
-        lastMessageId: lastMessage.id,
-      });
-    } catch (error) {
-      set({
-        error: error instanceof Error ? error.message : "Unknown error",
-        isLoading: false,
-      });
-    }
+    await attemptFetch(1);
   },
-  clearSuggestions: () => set({ suggestions: [], lastMessageId: null }),
+  clearSuggestions: () =>
+    set({
+      suggestions: [],
+      lastMessageId: null,
+      retryCount: 0,
+      error: null,
+      hasFailedForMessage: null,
+    }),
 }));

--- a/listen-interface/src/store/suggestStore.ts
+++ b/listen-interface/src/store/suggestStore.ts
@@ -58,7 +58,7 @@ export const useSuggestStore = create<SuggestState>((set, get) => ({
       const token = await getAccessToken();
       const response = await fetch(
         process.env.NODE_ENV === "production"
-          ? "https://api.listen-rs.com/v1/suggest"
+          ? "https://api.listen-rs.com/v1/kit/suggest"
           : "http://localhost:6969/suggest",
         {
           method: "POST",

--- a/listen-interface/src/store/suggestStore.ts
+++ b/listen-interface/src/store/suggestStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import { Message } from "../types/message";
+
+interface Suggestion {
+  text: string;
+}
+
+interface SuggestState {
+  suggestions: Suggestion[];
+  isLoading: boolean;
+  error: string | null;
+  fetchSuggestions: (
+    chatHistory: Message[],
+    getAccessToken: () => Promise<string>,
+    locale?: string
+  ) => Promise<void>;
+}
+
+export const useSuggestStore = create<SuggestState>((set) => ({
+  suggestions: [],
+  isLoading: false,
+  error: null,
+  fetchSuggestions: async (
+    chatHistory: Message[],
+    getAccessToken: () => Promise<string>,
+    locale = "en"
+  ) => {
+    set({ isLoading: true, error: null });
+    try {
+      const token = await getAccessToken();
+      const response = await fetch(
+        process.env.NODE_ENV === "production"
+          ? "https://api.listen-rs.com/v1/suggest"
+          : "http://localhost:6969/suggest",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            chat_history: chatHistory,
+            locale,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch suggestions");
+      }
+
+      const data = await response.json();
+      set({ suggestions: data.suggestions, isLoading: false });
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Unknown error",
+        isLoading: false,
+      });
+    }
+  },
+}));

--- a/listen-interface/src/store/versionStore.ts
+++ b/listen-interface/src/store/versionStore.ts
@@ -7,7 +7,7 @@ const VersionResponseSchema = z.object({
 
 const POLL_INTERVAL = 15000;
 
-export const CURRENT_VERSION = "2.6.1";
+export const CURRENT_VERSION = "2.6.2";
 
 interface VersionState {
   version: string;

--- a/listen-interface/src/store/versionStore.ts
+++ b/listen-interface/src/store/versionStore.ts
@@ -7,7 +7,7 @@ const VersionResponseSchema = z.object({
 
 const POLL_INTERVAL = 15000;
 
-export const CURRENT_VERSION = "2.5.0";
+export const CURRENT_VERSION = "2.6.0";
 
 interface VersionState {
   version: string;

--- a/listen-interface/src/store/versionStore.ts
+++ b/listen-interface/src/store/versionStore.ts
@@ -7,7 +7,7 @@ const VersionResponseSchema = z.object({
 
 const POLL_INTERVAL = 15000;
 
-export const CURRENT_VERSION = "2.6.0";
+export const CURRENT_VERSION = "2.6.1";
 
 interface VersionState {
   version: string;

--- a/listen-kit/src/data/listen_api_tools.rs
+++ b/listen-kit/src/data/listen_api_tools.rs
@@ -67,6 +67,32 @@ pub async fn fetch_token_metadata(mint: String) -> Result<serde_json::Value> {
 }
 
 #[tool(description = "
+Fetch token price from the Listen API.
+
+Parameters:
+- mint (string): The token's mint/pubkey address
+
+Returns the price of the token in USD.
+")]
+pub async fn fetch_token_price(mint: String) -> Result<f64> {
+    let response = reqwest::get(format!("{}/price?mint={}", API_BASE, mint))
+        .await
+        .map_err(|e| anyhow!("Failed to fetch token price: {}", e))?;
+
+    let data = response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|e| anyhow!("Failed to parse response: {}", e))?;
+
+    let price = match data["price"].as_f64() {
+        Some(price) => price,
+        None => return Err(anyhow!("Failed to parse price: {}", data)),
+    };
+
+    Ok(price)
+}
+
+#[tool(description = "
 Fetch top tokens from the Listen API.
 
 No point using limit of more than ~6, less is more, as long as the filters are right

--- a/listen-kit/src/http/routes/auth.rs
+++ b/listen-kit/src/http/routes/auth.rs
@@ -1,0 +1,20 @@
+use crate::http::middleware::verify_auth;
+use actix_web::{get, Error, HttpRequest, HttpResponse, Responder};
+use anyhow::Result;
+use serde_json::json;
+
+#[get("/auth")]
+async fn auth(req: HttpRequest) -> Result<HttpResponse, Error> {
+    let user_session = match verify_auth(&req).await {
+        Ok(session) => session,
+        Err(e) => {
+            return Ok(HttpResponse::Unauthorized()
+                .json(json!({ "error": e.to_string() })))
+        }
+    };
+
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "ok",
+        "wallet_address": user_session.wallet_address,
+    })))
+}

--- a/listen-kit/src/http/routes/auth.rs
+++ b/listen-kit/src/http/routes/auth.rs
@@ -1,5 +1,5 @@
 use crate::http::middleware::verify_auth;
-use actix_web::{get, Error, HttpRequest, HttpResponse, Responder};
+use actix_web::{get, Error, HttpRequest, HttpResponse};
 use anyhow::Result;
 use serde_json::json;
 

--- a/listen-kit/src/http/routes/healthz.rs
+++ b/listen-kit/src/http/routes/healthz.rs
@@ -1,0 +1,10 @@
+use actix_web::{get, Error, HttpResponse};
+use serde_json::json;
+
+#[get("/healthz")]
+async fn healthz() -> Result<HttpResponse, Error> {
+    Ok(HttpResponse::Ok().json(json!({
+        "status": "ok",
+        "timestamp": chrono::Utc::now().to_rfc3339()
+    })))
+}

--- a/listen-kit/src/http/routes/mod.rs
+++ b/listen-kit/src/http/routes/mod.rs
@@ -1,0 +1,11 @@
+pub mod stream;
+pub use stream::*;
+
+pub mod healthz;
+pub use healthz::*;
+
+pub mod auth;
+pub use auth::*;
+
+pub mod suggest;
+pub use suggest::*;

--- a/listen-kit/src/http/routes/stream.rs
+++ b/listen-kit/src/http/routes/stream.rs
@@ -1,9 +1,9 @@
-use super::middleware::verify_auth;
-use super::serde::deserialize_messages;
-use super::state::AppState;
 use crate::common::spawn_with_signer;
 use crate::cross_chain::agent::create_cross_chain_agent;
 use crate::evm::agent::create_evm_agent;
+use crate::http::middleware::verify_auth;
+use crate::http::serde::deserialize_messages;
+use crate::http::state::AppState;
 use crate::reasoning_loop::Model;
 use crate::reasoning_loop::ReasoningLoop;
 use crate::reasoning_loop::StreamResponse;
@@ -12,16 +12,12 @@ use crate::signer::TransactionSigner;
 use crate::solana::agent::create_solana_agent;
 use crate::solana::agent::create_solana_agent_gemini;
 use crate::solana::agent::Features;
-use actix_web::{
-    get, post, web, Error, HttpRequest, HttpResponse, Responder,
-};
+use actix_web::{post, web, HttpRequest, Responder};
 use actix_web_lab::sse;
-use anyhow::Result;
 use futures::StreamExt;
 use mongodb::bson::doc;
 use rig::completion::Message;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use std::sync::Arc;
 
 #[derive(Deserialize, Serialize, Clone)]
@@ -395,28 +391,4 @@ fn join_responses(
     }
 
     output_responses
-}
-
-#[get("/healthz")]
-async fn healthz() -> Result<HttpResponse, Error> {
-    Ok(HttpResponse::Ok().json(json!({
-        "status": "ok",
-        "timestamp": chrono::Utc::now().to_rfc3339()
-    })))
-}
-
-#[get("/auth")]
-async fn auth(req: HttpRequest) -> Result<HttpResponse, Error> {
-    let user_session = match verify_auth(&req).await {
-        Ok(session) => session,
-        Err(e) => {
-            return Ok(HttpResponse::Unauthorized()
-                .json(json!({ "error": e.to_string() })))
-        }
-    };
-
-    Ok(HttpResponse::Ok().json(json!({
-        "status": "ok",
-        "wallet_address": user_session.wallet_address,
-    })))
 }

--- a/listen-kit/src/http/routes/suggest.rs
+++ b/listen-kit/src/http/routes/suggest.rs
@@ -1,0 +1,47 @@
+use crate::http::serde::deserialize_messages;
+use crate::{http::middleware::verify_auth, suggester};
+use actix_web::{post, web, Error, HttpRequest, HttpResponse};
+use rig::message::Message;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct SuggestRequest {
+    #[serde(deserialize_with = "deserialize_messages")]
+    chat_history: Vec<Message>,
+    locale: Option<String>,
+}
+
+#[post("/suggest")]
+async fn suggest(
+    req: HttpRequest,
+    body: web::Json<SuggestRequest>,
+) -> Result<HttpResponse, Error> {
+    let chat_history = body.chat_history.clone();
+    let _ = match verify_auth(&req).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("Error: unauthorized: {}", e);
+            return Ok(HttpResponse::Unauthorized().json(json!({
+                "error": "unauthorized"
+            })));
+        }
+    };
+    let suggestions = match suggester::suggest(
+        &chat_history,
+        body.locale.as_deref().unwrap_or("en"),
+    )
+    .await
+    {
+        Ok(suggestions) => suggestions,
+        Err(e) => {
+            tracing::error!("Error: failed to suggest: {}", e);
+            return Ok(HttpResponse::InternalServerError().json(json!({
+                "error": format!("failed to suggest: {}", e)
+            })));
+        }
+    };
+    Ok(HttpResponse::Ok().json(json!({
+        "suggestions": suggestions
+    })))
+}

--- a/listen-kit/src/http/routes/suggest.rs
+++ b/listen-kit/src/http/routes/suggest.rs
@@ -12,7 +12,7 @@ pub struct SuggestRequest {
     locale: Option<String>,
 }
 
-serde#[post("/suggest")]
+#[post("/suggest")]
 async fn suggest(
     req: HttpRequest,
     body: web::Json<SuggestRequest>,
@@ -28,9 +28,9 @@ async fn suggest(
         }
     };
     // tmp
-    Ok(HttpResponse::Ok().json(json!({
+    return Ok(HttpResponse::Ok().json(json!({
         "suggestions": []
-    })))
+    })));
     let suggestions = match suggester::suggest(
         &chat_history,
         body.locale.as_deref().unwrap_or("en"),

--- a/listen-kit/src/http/routes/suggest.rs
+++ b/listen-kit/src/http/routes/suggest.rs
@@ -27,10 +27,6 @@ async fn suggest(
             })));
         }
     };
-    // tmp
-    return Ok(HttpResponse::Ok().json(json!({
-        "suggestions": []
-    })));
     let suggestions = match suggester::suggest(
         &chat_history,
         body.locale.as_deref().unwrap_or("en"),

--- a/listen-kit/src/http/routes/suggest.rs
+++ b/listen-kit/src/http/routes/suggest.rs
@@ -12,7 +12,7 @@ pub struct SuggestRequest {
     locale: Option<String>,
 }
 
-#[post("/suggest")]
+serde#[post("/suggest")]
 async fn suggest(
     req: HttpRequest,
     body: web::Json<SuggestRequest>,
@@ -27,6 +27,10 @@ async fn suggest(
             })));
         }
     };
+    // tmp
+    Ok(HttpResponse::Ok().json(json!({
+        "suggestions": []
+    })))
     let suggestions = match suggester::suggest(
         &chat_history,
         body.locale.as_deref().unwrap_or("en"),

--- a/listen-kit/src/http/server.rs
+++ b/listen-kit/src/http/server.rs
@@ -17,12 +17,18 @@ pub async fn run_server(
         App::new()
             .wrap(Logger::default())
             .wrap(Compress::default())
-            .wrap(Cors::permissive())
+            .wrap(
+                Cors::default()
+                    .allow_any_origin()
+                    .allow_any_method()
+                    .allow_any_header()
+                    .max_age(3600),
+            )
             .app_data(state.clone())
             .service(healthz)
             .service(stream)
             .service(auth)
-        // .service(suggest)
+            .service(suggest)
     })
     .bind("0.0.0.0:6969")?
     .run()

--- a/listen-kit/src/http/server.rs
+++ b/listen-kit/src/http/server.rs
@@ -3,7 +3,7 @@ use actix_web::middleware::{Compress, Logger};
 use actix_web::{web, App, HttpServer};
 use privy::Privy;
 
-use super::routes::{auth, healthz, stream};
+use super::routes::{auth, healthz, stream, suggest};
 use super::state::AppState;
 use crate::mongo::MongoClient;
 
@@ -22,6 +22,7 @@ pub async fn run_server(
             .service(healthz)
             .service(stream)
             .service(auth)
+            .service(suggest)
     })
     .bind("0.0.0.0:6969")?
     .run()

--- a/listen-kit/src/http/server.rs
+++ b/listen-kit/src/http/server.rs
@@ -22,7 +22,7 @@ pub async fn run_server(
             .service(healthz)
             .service(stream)
             .service(auth)
-            .service(suggest)
+        // .service(suggest)
     })
     .bind("0.0.0.0:6969")?
     .run()

--- a/listen-kit/src/lib.rs
+++ b/listen-kit/src/lib.rs
@@ -26,6 +26,8 @@ pub mod web;
 
 pub mod tokenizer;
 
+pub mod suggester;
+
 #[ctor::ctor]
 fn init() {
     dotenv::dotenv().ok();

--- a/listen-kit/src/solana/agent.rs
+++ b/listen-kit/src/solana/agent.rs
@@ -7,7 +7,8 @@ use crate::common::{
 };
 use crate::data::{
     AnalyzePageContent, FetchPriceActionAnalysis, FetchTokenMetadata,
-    FetchTopTokens, FetchXPost, ResearchXProfile, SearchTweets, SearchWeb,
+    FetchTokenPrice, FetchTopTokens, FetchXPost, ResearchXProfile,
+    SearchTweets, SearchWeb,
 };
 use crate::dexscreener::tools::SearchOnDexScreener;
 use crate::solana::advanced_orders::CreateAdvancedOrder;
@@ -42,6 +43,7 @@ pub async fn create_solana_agent(
         .tool(GetSplTokenBalance)
         .tool(SearchOnDexScreener)
         .tool(FetchTopTokens)
+        .tool(FetchTokenPrice)
         .tool(DeployPumpFunToken)
         .tool(FetchTokenMetadata)
         .tool(ResearchXProfile)

--- a/listen-kit/src/solana/tools.rs
+++ b/listen-kit/src/solana/tools.rs
@@ -175,9 +175,10 @@ pub async fn get_public_key() -> Result<String> {
 }
 
 #[tool(description = "
-Returns the current SOL balance of the a wallet (given as pubkey param)
+Returns the current Solana balance of the delegated wallet wallet
 ")]
-pub async fn get_sol_balance(pubkey: String) -> Result<u64> {
+pub async fn get_sol_balance() -> Result<u64> {
+    let pubkey = "".to_string();
     match pubkey.as_str() {
         "" => {
             wrap_unsafe(move || async move {
@@ -208,6 +209,7 @@ pub async fn get_sol_balance(pubkey: String) -> Result<u64> {
 
 #[tool(description = "
 get_token_balance returns (amount as String, decimals as u8, mint as String) - your current balance of the any SPL token
+SPL token is any solana token that is not SOL
 in order to convert to UI amount: amount / 10^decimals
 ")]
 pub async fn get_spl_token_balance(

--- a/listen-kit/src/suggester/mod.rs
+++ b/listen-kit/src/suggester/mod.rs
@@ -7,11 +7,14 @@ use rig::{
 
 const PROMPT_EN: &str = r#"
 Strictly based on this conversation, generate 2-3 follow-up suggestions for what
-I can do next. One per line, each 4-5 words.
+I can do next. One per line, each 4-5 words, provide only the suggestions, no other text.
+Special case: if the last assistant message is a question, where specific
+choices are provided, provide those choices
 "#;
 
 const PROMPT_ZH: &str = r#"
-严格基于这段对话，生成2-3个后续建议，告诉我接下来可以做什么。每行一个，每个4-5个字。
+严格基于这段对话，生成2-3个后续建议，告诉我接下来可以做什么。每行一个，每个4-5个字，只提供建议，不要其他文字。
+特殊情况：如果最后一条助手消息是一个问题，并且提供了具体的选择，请提供这些选择。
 "#;
 
 const MAX_CHARS: usize = 30000;

--- a/listen-kit/src/suggester/mod.rs
+++ b/listen-kit/src/suggester/mod.rs
@@ -6,11 +6,12 @@ use rig::{
 };
 
 const PROMPT_EN: &str = r#"
-Strictly based on this conversation, generate 2-3 follow-up questions for what I can do next. One per line:
+Strictly based on this conversation, generate 2-3 follow-up suggestions for what
+I can do next. One per line, each 4-5 words.
 "#;
 
 const PROMPT_ZH: &str = r#"
-严格基于这段对话，生成2-3个后续问题，告诉我接下来可以做什么。每行一个：
+严格基于这段对话，生成2-3个后续建议，告诉我接下来可以做什么。每行一个，每个4-5个字。
 "#;
 
 const MAX_CHARS: usize = 30000;

--- a/listen-kit/src/suggester/mod.rs
+++ b/listen-kit/src/suggester/mod.rs
@@ -1,0 +1,127 @@
+use crate::common::gemini_agent_builder;
+use anyhow::Result;
+use rig::{
+    completion::Prompt,
+    message::{AssistantContent, Message, ToolResultContent, UserContent},
+};
+
+const PREAMBLE_EN: &str = r#"You are a helpful AI assistant focused on
+suggesting relevant follow-up questions.  Based on the conversation history,
+dynamically suggest follow-up prompts that are most likely to be useful. Focus
+on questions that explore underlying concepts, technical details, or practical
+applications. Make suggestions concise and specific."#;
+
+const PREAMBLE_ZH: &str = r#"你是一个专注于提供相关后续问题的AI助手。
+根据对话历史，建议2个后续提示，这些提示有助于加深理解并触发额外研究。
+重点关注探索基本概念、技术细节或实际应用的问题。建议要简洁具体。"#;
+
+pub async fn suggest(
+    messages: &[Message],
+    locale: &str,
+) -> Result<Vec<String>> {
+    let preamble = if locale == "zh" {
+        PREAMBLE_ZH
+    } else {
+        PREAMBLE_EN
+    };
+
+    let agent = gemini_agent_builder().preamble(preamble).build();
+    let max_chars = 30000;
+
+    let prompt = format!(
+        "{}\n\nBased on this conversation, provide exactly 2 follow-up questions, one per line:",
+        messages_to_string(messages, max_chars)
+    );
+
+    let response = agent.prompt(Message::user(prompt)).await?;
+
+    // Split response into lines and take exactly 4 suggestions
+    let suggestions: Vec<String> = response
+        .lines()
+        .filter(|line| !line.is_empty())
+        .take(4)
+        .map(|s| s.trim().to_string())
+        .collect();
+
+    Ok(suggestions)
+}
+
+fn messages_to_string(messages: &[Message], max_chars: usize) -> String {
+    let snippet = messages
+        .iter()
+        .map(|m| format!("{}: {}", role(m), content(m)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if snippet.len() > max_chars {
+        "...".to_string() + &snippet[snippet.len() - max_chars..]
+    } else {
+        snippet
+    }
+}
+
+fn role(message: &Message) -> String {
+    match message {
+        Message::User { .. } => "user".to_string(),
+        Message::Assistant { .. } => "assistant".to_string(),
+    }
+}
+
+fn content(message: &Message) -> String {
+    match message {
+        Message::User { content } => match content.first() {
+            UserContent::Text(text) => text.text.clone(),
+            UserContent::ToolResult(tool_result) => {
+                match tool_result.content.first() {
+                    ToolResultContent::Text(text) => text.text.clone(),
+                    _ => "".to_string(),
+                }
+            }
+            UserContent::Image(_) => "".to_string(),
+            UserContent::Audio(_) => "".to_string(),
+            UserContent::Document(_) => "".to_string(),
+        },
+        Message::Assistant { content } => match content.first() {
+            AssistantContent::Text(text) => text.text.clone(),
+            AssistantContent::ToolCall(tool_call) => {
+                let call = format!(
+                    "called {} with {}",
+                    tool_call.function.name, tool_call.function.arguments
+                );
+                call
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::message::Message;
+
+    #[tokio::test]
+    async fn test_suggest_en() {
+        let messages = vec![
+            Message::user("How does Solana achieve high transaction throughput?".to_string()),
+            Message::assistant(
+                "Solana achieves high throughput through parallel processing and Proof of History.".to_string(),
+            ),
+        ];
+
+        let suggestions = suggest(&messages, "en").await.unwrap();
+        println!("{:?}", suggestions);
+    }
+
+    #[tokio::test]
+    async fn test_suggest_zh() {
+        let messages = vec![
+            Message::user("Solana如何实现高交易吞吐量？".to_string()),
+            Message::assistant(
+                "Solana通过并行处理和历史证明机制实现高吞吐量。".to_string(),
+            ),
+        ];
+
+        let suggestions = suggest(&messages, "zh").await.unwrap();
+        println!("{:?}", suggestions);
+    }
+}


### PR DESCRIPTION
feat: Add context-aware suggestions during chat

This PR adds a new feature that provides context-sensitive follow-up suggestions during chat interactions:

- Adds an API endpoint `/suggest` to generate contextual suggestions
- Implements a suggestion store to manage suggestion state 
- Adds UI components to display suggestions as interactive tiles
- Makes suggestions configurable via settings
- Updates version to 2.6.0

Other changes:
- Improves token price fetching with a new tool
- Refactors routes organization
- Enhances error handling for model switching
- Adds translations for new features